### PR TITLE
fix typos in exercise w01

### DIFF
--- a/compendium/modules/w01-exercise.tex
+++ b/compendium/modules/w01-exercise.tex
@@ -171,7 +171,7 @@ scala> println(println("hej"))
 \Subtask \code{42 % 2}
 
 
-\Task \textit{Hetalsomfång}. För var och en av heltalstyperna i deluppgifterna nedan: undersök i REPL med operationen \code{MaxValue} resp. \code{MinValue}, vad som är största och minsta värde, till exempel \code{Int.MaxValue} etc. 
+\Task \textit{Heltalsomfång}. För var och en av heltalstyperna i deluppgifterna nedan: undersök i REPL med operationen \code{MaxValue} resp. \code{MinValue}, vad som är största och minsta värde, till exempel \code{Int.MaxValue} etc.
 
 \Subtask \code{Byte}
 
@@ -194,13 +194,13 @@ scala> scala.math.        //tryck TAB
 \Subtask Undersök dokumentationen för klassen \code{java.lang.Math} här: \\ \url{https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html} \\
 Vad gör \code{java.lang.Math.hypot}?
 
-\Subtask Undersök dokumentationen för pakobjektet \code{scala.math} här: \\
+\Subtask Undersök dokumentationen för paketobjektet \code{scala.math} här: \\
 \url{http://www.scala-lang.org/api/current/#scala.math.package} \\
 Ge exempel på någon funktion i \code{java.lang.Math} som inte finns i \code{scala.math}.
 
 %\TaskSection{Noggranhet och undantag i aritmetiska uttryck}
 
-\Task Vad händer här? Notera undantag \Eng{exceptions} och nogranhetsproblem. 
+\Task Vad händer här? Notera undantag \Eng{exceptions} och noggrannhetsproblem.
 
 \Subtask \code{Int.MaxValue} + 1
 
@@ -445,13 +445,13 @@ scala> math.random
 scala> for (i <- 1 to 10) println(math.random)
 \end{REPLnonum}
 
-\Subtask Skriv en for-sats som skriver ut 100 slumpmässiga heltal från 0 till och med 9 på var sin rad. 
+\Subtask Skriv en \code{for}-sats som skriver ut 100 slumpmässiga heltal från 0 till och med 9 på var sin rad.
 
 \begin{REPLnonum}
 scala> for (i <- 1 to 100) println(???)
 \end{REPLnonum}
 
-\Subtask Skriv en for-sats som skriver ut 100 slumpmässiga heltal från 1 till och med 6 på samm rad. 
+\Subtask Skriv en \code{for}-sats som skriver ut 100 slumpmässiga heltal från 1 till och med 6 på samma rad.
 
 \begin{REPLnonum}
 scala> for (i <- 1 to 100) print(???)
@@ -464,7 +464,7 @@ scala> for (i <- 1 to 100) print(???)
 scala> while (math.random > 0.2) println("gurka")
 \end{REPLnonum}
 
-\Subtask Ändra i \code{while}-satsen ovan så att sannolikheten ökar att riktigt många  strängar ska skrivs ut.
+\Subtask Ändra i \code{while}-satsen ovan så att sannolikheten ökar att riktigt många strängar ska skrivas ut.
 
 \Subtask Förklara vad som händer nedan.
 \begin{REPL}
@@ -498,7 +498,7 @@ scala> while (slumptal > 0.2) { println(slumptal); slumptal = math.random }
 scala> def tärning = (math.random * ??? + ???).toInt 
 \end{REPLnonum}
 
-\Subtask Ersätt \code{???} med literaler så att rnd blir ett decimaltal med max en decimal mellan 0.0 och 1.0.
+\Subtask Ersätt \code{???} med literaler så att \code{rnd} blir ett decimaltal med max en decimal mellan 0.0 och 1.0.
 \begin{REPLnonum}
 scala> def rnd = math.round(math.random * ???) / ??? 
 \end{REPLnonum}
@@ -543,7 +543,7 @@ scala> Math.multiplyExact(Int.MaxValue, Int.MaxValue)
 Se även språkspecifikationen för Scala, kapitlet om heltalsliteraler: \\
 \url{http://www.scala-lang.org/files/archive/spec/2.11/01-lexical-syntax.html#integer-literals}
 
-\Subtask Undersök källkoden för pakobjektet \code{scala.math} här: \\
+\Subtask Undersök källkoden för paketobjektet \code{scala.math} här: \\
 \url{https://github.com/scala/scala/blob/v2.11.7/src/library/scala/math/package.scala} \\
 Hur många olika överlagrade varianter av funktionen \code{abs} finns det och för vilka parametertyper är den definierad?
 


### PR DESCRIPTION
Fixed every typo that I could find in the first exercise. 

I am not sure whether the added `\code{}` blocks are classed as typos, but it seemed better to keep the style consistent.

Any comments and feedback would be appreciated!

(`sbt pdf` asserts success!)