### PR TITLE
Update turtlegraphics Point specification.

### DIFF
--- a/compendium/modules/w06-lab.tex
+++ b/compendium/modules/w06-lab.tex
@@ -102,18 +102,16 @@ Med hjälp utav SimpleWindow kan vi nu skapa en Turtle-klass som fungerar likt d
 
 \subsection{Obligatoriska uppgifter}
 
-\Task Skapa en klass Point för att beskriva en viss koordinat (x,y) i ett fönster. Klassen ska vara omuterbar - man ska alltså inte kunna ändra på en koordinat efter att den har skapats.
+\Task Skapa en klass Point för att beskriva en viss koordinat (x,y) i ett fönster. Klassen ska vara omuterbar - man ska alltså inte kunna ändra på en koordinat efter att den har skapats. Notera att klassens attribut är av typen Double och inte Int, trots att de i någon mån beskriver en diskret pixelposition. Anledningen till detta är att det kan uppstå avrundningsfel vid upprepade förflyttningar. Detta blir särskilt märkbart då varje förflyttning är liten, som t.ex. när en Turtle används för att rita en cirkel.
 
 \begin{ScalaSpec}{Point}
 /** Represents a single Point in the x,y plane. */
-case class Point(val x: Number, val y: Number) {
+case class Point(val x: Double, val y: Double) {
 
 ** Returns a new Point which has been moved some number of pixels */
-def translate(dx: Number, dy: Number) = ???
+def translate(dx: Double, dy: Double) = ???
 }
 \end{ScalaSpec}
-
-\Subtask Hur borde specifikationen för Point se ut? Vilka typer bör attributen ha? De bör inte ha typen Number.
 
 \Subtask Implementera klassen Point.
 
@@ -193,7 +191,6 @@ class Turtle(window: SimpleWindow, private var position: Point,
 \textbf{Tips:}
 \begin{itemize}
 \item SimpleWindow har sitt origo i övre vänstra hörnet, till skillnad från det nedre vänstra hörnet som är vanligt inom matematik.
-\item Om din cirkel inte blev som förväntad, fundera på din implementation av Point. Var förekommer avrundningar?
 \end{itemize}
 
 \Task Skapa klassen Rectangle: 


### PR DESCRIPTION
The specification for Point no longer leaves out the type of the x,y parameters. Instead, the type is given upfront and the reasoning behind the choice is explained.