### PR TITLE
Wrong answer exercise 20:5

### DIFF
--- a/compendium/modules/w01-solutions.tex
+++ b/compendium/modules/w01-solutions.tex
@@ -364,7 +364,7 @@ println(s"$e har  $eTot bokstäver.")
 
 1, 11, 21, 31, 41, 51, 61, 71, 81, 91,
 
-inget
+1, 2, 3, 4, 5, 6, 7, 8, 9, 10
 
 \Subtask 
 


### PR DESCRIPTION
This is the current code in the compendium and it prints 10, 9, 8, 7, 6, 5, 4, 3, 2, 1
`for (i <- 10 to 1 by -1) print(i + ", ")`

The -1 sign in the for loop is probably supposed to be 1 instead, because then the print will be empty and also correct according to the answer?
`for (i <- 10 to 1 by 1) print(i + ", ")`