### PR TITLE
Updated if-statement to check if key exists to prevent NoSuchElementE…

### DIFF
--- a/workspace/w05_shuffle/src/main/scala/cardSimulation/PokerProbability.scala
+++ b/workspace/w05_shuffle/src/main/scala/cardSimulation/PokerProbability.scala
@@ -52,7 +52,7 @@ object PokerProbability {
     val n = scala.io.StdIn.readInt()
     val res = test(n)
     for (hand <- everyHand)
-      if (res(hand) > 0) {
+      if (res.contains(hand) && res(hand) > 0) {
         val percent = res(hand).toDouble / n * 100
         println(f"$hand: $percent%.4f%%")
       }


### PR DESCRIPTION
…xception

If the key that we want to access, for example Royal flush, does not exist in the map scala will throw an exception and we must therefore check if it exists for the program to work