### PR TITLE
Added "_=" to identify the methods as a setter in Exercise 6.11e

### DIFF
--- a/compendium/modules/w06-solutions.tex
+++ b/compendium/modules/w06-solutions.tex
@@ -290,11 +290,11 @@ class Frog private (initX: Int = 0, initY: Int = 0) {
 	def x: Int = _x
 	def y: Int = _y
 	
-	def x(newX: Int): Unit = {
+	def x_= (newX: Int): Unit = {
 		_distanceJumped += Math.abs(_x - newX)
 		_x = newX
 	} 
-	def y(newY: Int): Unit = {
+	def y_= (newY: Int): Unit = {
 		_distanceJumped += Math.abs(_y - newY)
 		_y = newY
 	} 


### PR DESCRIPTION
The current methods `def x` and `def y` are not correct setters (they are normal methods). They are missing: `_=` which identifies them as setters.

