### PR TITLE
fix maze path being dependent on CWD; use resource dir

### DIFF
--- a/workspace/w09_maze/src/main/scala/maze/AMazeIngRace.scala
+++ b/workspace/w09_maze/src/main/scala/maze/AMazeIngRace.scala
@@ -3,6 +3,7 @@ package maze
 import cslib.window.SimpleWindow
 import java.awt.Color
 import java.io.File
+import java.nio.file.Paths
 
 object AMazeIngRace {
   def printMazesFromDir(filepath: String): Unit = {
@@ -54,8 +55,10 @@ object AMazeIngRace {
     }
   }
 
+  def getMazeDirectoryPath : String = Paths.get(getClass().getResource("/maze1.txt").toURI).toFile.getParent+File.separator
+
   def main(args: Array[String]): Unit = {
-    val path = (new File(".")).getCanonicalPath + "/src/main/resources/"
+    val path = getMazeDirectoryPath
     val w = new SimpleWindow(800, 800, "A-Maze-Ing Race")
     printMazesFromDir(path)
     w.moveTo(10, 100)


### PR DESCRIPTION
I could not run the maze lab on {linux, windows} + IntelliJ (with sbt plugin) due to the use of `new File(".")` which in IntelliJ yields the root project (workspace/) rather than the submodule (w09_maze).

Normally, we could get around this by not explicitly relying on a directory path, but just using `getResource(filename)` to access the maze files. However, since the lab is explicitly teaching file handling rather than resource use, I instead fixed the problem by dynamically getting the directory where the resources are stored.

Tested and working on following platforms:
linux + sbt
linux + IntelliJ IDEA (with sbt plugin)
windows + IntelliJ IDEA (with sbt plugin)

What do you think? Is it confusing to the students to use a path which is somewhere in the target/ directory?