### PR TITLE
survey2: Improve path handling

### DIFF
--- a/workspace/w10_survey2/src/main/scala/stats/Command.scala
+++ b/workspace/w10_survey2/src/main/scala/stats/Command.scala
@@ -39,10 +39,8 @@ object Command {
       |             Terminates the program""".stripMargin
 
   def load(uri: String, sep: String): Table = {
-    lazy val path = getClass.getResource("/").getPath
-    val location = if (uri.startsWith("http")) uri else s"$path$uri"
-    println(s"""Loading $location with separator '$sep' to table ...\n""")
-    val t =  Table.fromFile(location, sep)
+    println(s"""Loading $uri with separator '$sep' to table ...\n""")
+    val t = Table.fromFile(uri, sep)
     println(s"Done. Size: ${t.dim._1}x${t.dim._2}.\n")
     t
   }

--- a/workspace/w10_survey2/src/main/scala/stats/Main.scala
+++ b/workspace/w10_survey2/src/main/scala/stats/Main.scala
@@ -9,7 +9,7 @@ object Main {
 
   def main(args: Array[String]): Unit = {
     Try {
-      val path = getClass.getResource("/").getPath
+      val path = Table.getResourcePath("")
       println(welcome)
       println(s"Current dir: $path")
       println(Command.helpMsg)
@@ -21,7 +21,7 @@ object Main {
           val table = Command.load(uri, sep)
           Command.loop(tableOpt=Some(table))
 
-        case _ => println(s"""Unkown args: ${args.mkString(" ")}$usage""")
+        case _ => println(s"""Unknown args: ${args.mkString(" ")}$usage""")
       }
     }.recover {
       case e: Throwable =>


### PR DESCRIPTION
- The code for getting the resource directory is now only in one place instead of three.
- The same fix as in 45ec99f is applied, making special characters work in paths. (Writing paths with spaces during the command loop is impossible for command parsing reasons, but spaces do work in paths provided as arguments to main.)
- Instead of having hardcoded checks for strings starting with "http", the program now determines if something is a URL by trying to create a URL object from it. If there is no valid protocol, a MalformedURLException is thrown, which we catch.
- Path.resolve is now used instead of string concatenation, which lets the user optionally enter absolute paths.

I don't have access to many testing environments here, but it seems to work fine in at least Windows+IntelliJ.

Is it intentional that the `save` method doesn't use the resource directory as a base for relative paths, unlike `load`?