### PR TITLE
Fix example output in bank

### DIFF
--- a/compendium/modules/w13-assignment-bank.tex
+++ b/compendium/modules/w13-assignment-bank.tex
@@ -32,7 +32,7 @@ Kraven för bankapplikationen återfinns här nedan. För att bli godkänd på d
 
 \begin{itemize}
 \item 1. Hitta konton för en viss kontoinnehavare med angivet ID.
-\item 2. Söka efter kontoinnehavare på (del av) namn.
+\item 2. Söka efter kunder på (del av) namn.
 \item 3. Sätta in pengar på ett konto.
 \item 4. Ta ut pengar på ett konto.
 \item 5. Överföra pengar mellan två olika konton.
@@ -289,7 +289,7 @@ Listan över val, som är markerad i kursiv stil i det första exemplet, är int
 - - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
 \textit{
 1.   Hitta ett konto för en given kund\\*
-2.   Sök efter en kund utifrån (del av) angivet namn\\*
+2.   Sök efter kunder på (del av) namn\\*
 3.   Sätt in pengar\\*
 4.   Ta ut pengar\\*
 5.   Överför pengar mellan konton\\*
@@ -302,7 +302,7 @@ Listan över val, som är markerad i kursiv stil i det första exemplet, är int
 Val: \textbf{6}\\*
 Namn: \textbf{Adam Asson}\\*
 Id: \textbf{6707071234}\\*
-Nytt konto skapat med kontonummer: 1001\\*
+Nytt konto skapat med kontonummer: 1000\\*
 10:03:0 CET 14 / 5 - 2016\\
 - - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
 Val: \textbf{1}\\*
@@ -317,8 +317,8 @@ Nytt konto skapat med kontonummer: 1001\\*
 10:12:0 CET 14 / 5 - 2016\\
 - - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
 Val: \textbf{8}\\*
-Konto 1000 (Adam Asson, id 850127) 0 kr\\*
-Konto 1001 (Berit Besson, id 900318) 0 kr\\*
+Konto 1000 (Adam Asson, id 6707071234) 0 kr\\*
+Konto 1001 (Berit Besson, id 8505255678) 0 kr\\*
 10:13:0 CET 14 / 5 - 2016\\
 - - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
 Val: \textbf{2}\\*
@@ -334,8 +334,7 @@ Nytt konto skapat med kontonummer: 1002\\*
 - - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
 Val: \textbf{2}\\*
 Namn: \textbf{erit}\\*
-Konto 1001 (Berit Besson, id 900318) 0 kr\\*
-Konto 1002 (Berit Besson, id 900318) 0 kr\\*
+Berit Besson, id 8505255678\\*
 14:01:0 CET 14 / 5 - 2016\\
 - - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
 Val: \textbf{3}\\*
@@ -352,44 +351,42 @@ Transaktionen lyckades.\\*
 14:37:0 CET 14 / 5 - 2016\\
 - - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
 Val: \textbf{8}\\*
-Konto 1000 (Adam Asson, id 850127) 4000 kr\\*
-Konto 1001 (Berit Besson, id 900318) 1000 kr\\*
-Konto 1002 (Berit Besson, id 900318) 0 kr\\*
+Konto 1000 (Adam Asson, id 6707071234) 4000 kr\\*
+Konto 1001 (Berit Besson, id 8505255678) 1000 kr\\*
+Konto 1002 (Berit Besson, id 8505255678) 0 kr\\*
 14:52:0 CET 14 / 5 - 2016\\
 - - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
-Val: \textbf{2}\\*
+Val: \textbf{7}\\*
 Ange konto att radera: \textbf{1002}\\*
 Transaktionen lyckades.\\*
 14:01:0 CET 14 / 5 - 2016\\
 - - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
-Val: \textbf{7}\\*
-Namn: \textbf{erit}\\*
-Konto 1001 (Berit Besson, id 900318) 0 kr\\*
+Val: \textbf{8}\\*
+Konto 1000 (Adam Asson, id 6707071234) 4000 kr\\*
+Konto 1001 (Berit Besson, id 8505255678) 1000 kr\\*
 14:01:0 CET 14 / 5 - 2016\\
 - - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
 Val: \textbf{9}\\*
 Vilket datum vill du återställa banken till?\\*
 År: \textbf{2016}\\*
 Månad: \textbf{5}\\*
-Datum (dag): \textbf{14}\\*
-Timme: \textbf{10}\\*
-Minut: \textbf{5}\\*
+Datum (dag): \textbf{9}\\*
+Timme: \textbf{18}\\*
+Minut: \textbf{10}\\*
 Banken återställd.\\*
 15:00:0 CET 14 / 5 - 2016\\
 - - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
 Val: \textbf{8}\\*
-Konto 1000 (Adam Asson, id 850127) 0 kr\\*
+Konto 1002 (Björn, id 651002) 25900 kr\\*
+Konto 1001 (Casper, id 900318) 4600 kr\\*
+Konto 1003 (Eva, id 950908) 6300 kr\\*
+Konto 1000 (Fredrik, id 850127) 11800 kr\\*
+Konto 1004 (Kajsa, id 810722) 17000 kr\\*
 15:01:0 CET 14 / 5 - 2016\\
 - - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
 Val: \textbf{3}\\*
-Kontonummer: \textbf{1001}\\*
+Kontonummer: \textbf{1005}\\*
 Summa: \textbf{5000}\\*
 Transaktionen misslyckades. Inget sådant konto hittades.\\*
 15:06:0 CET 14 / 5 - 2016\\
-- - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
-Val: \textbf{3}\\*
-Kontonummer: \textbf{1001}\\*
-Summa: \textbf{5000}\\*
-Transaktionen misslyckades.  Otillräckligt saldo.\\*
-15:23:0 CET 14 / 5 - 2016\\
 \end{multicols}


### PR DESCRIPTION
There were a number of errors and inconsistencies in the example output for bank, including:

* Some outputs were being matched with the wrong user action (notably 3 and 7 being switched around). 
* ID numbers for the customers in the examples were not consistent throughout the examples
* The outputs for user action 2 (find customers by name) were inconsistent. Some showed listed accounts and others listed customers only. Since the specification has a `findByName` method (returning Customers) and it is only used for this purpose, I changed all of the examples to only list the customers and not their accounts.

I also changed the example output for 8 (restoring to old state) to be usable as a test case for the log file provided in the workspace.

TLDR: Examples fixed. Action 2 should return customers only. Action 8 can be tested using the example output.