### PR TITLE
lthopoly: Make game board printout in instructions accurate

### DIFF
--- a/compendium/modules/w12-lab.tex
+++ b/compendium/modules/w12-lab.tex
@@ -275,20 +275,20 @@ Rutans Namn [Ägare] (Pris/Hyra) (Spelare, Pengar)*
 ---------------------------------------------------------------
 Studiecentrum(20)
 A-huset(25) 
-ChansRuta 
-ChansRuta (Jonas,350)
+MoneySpace
+MoneySpace (Jonas,350)
 Moroten och piskan(40) (Oskar,260)
 V-Huset [Valthor](45) (Valthor,255)
-RiskRuta 
-ChansRuta 
-LED-Cafe(70) 
-F-Huset(75) 
-ChansRuta 
-RiskRuta 
-Ideet(80) 
-ChansRuta 
-E-huset(100) 
-RiskRuta
+MoveSpace
+MoneySpace
+LED-Cafe(70)
+F-Huset(75)
+MoneySpace
+MoveSpace
+Ideet(80)
+MoneySpace
+E-huset(100)
+MoveSpace
 
 Välj ett alternativ:
 


### PR DESCRIPTION
lthopoly uses money and move spaces, not risk and chance spaces.