### PR TITLE
Add expanded footnote about comparison and Unicode

### DIFF
--- a/compendium/modules/w11-exercise.tex
+++ b/compendium/modules/w11-exercise.tex
@@ -22,7 +22,7 @@
 
 \BasicTasks %%%%%%%%%%%%%%%%
 
-\Task \label{task:string-order-operators}\emph{Jämföra strängar i Scala.} I Scala kan strängar jämföras med operatorerna \code{==}, \code{!=}, \code{<}, \code{<=}, \code{>}, \code{>=},  där likhet/olikhet avgörs av om alla tecken i strängen är lika eller inte, medan större/mindre avgörs av sorteringsordningen i enlighet med varje teckens Unicode\footnote{\href{https://sv.wikipedia.org/wiki/Unicode}{sv.wikipedia.org/wiki/Unicode}}-värde. 
+\Task \label{task:string-order-operators}\emph{Jämföra strängar i Scala.} I Scala kan strängar jämföras med operatorerna \code{==}, \code{!=}, \code{<}, \code{<=}, \code{>}, \code{>=},  där likhet/olikhet avgörs av om alla tecken i strängen är lika eller inte, medan större/mindre avgörs av sorteringsordningen i enlighet med varje teckens Unicode-värde.\footnote{Överkurs: Alla tecken i en \code{java.lang.String} representeras enligt UTF-16-standarden (\href{https://en.wikipedia.org/wiki/UTF-16}{https://sv.wikipedia.org/wiki/UTF-16}), vilket innebär att varje Unicode-kodpunkt \Eng{code point} lagras som antingen ett eller två 16-bitars heltal. Strängjämförelse i Scala och Java jämför egentligen inte varje tecken, utan varje 16-bitars heltal. Denna skillnad har ingen betydelse när en sträng bara innehåller tecken som tar upp ett 16-bitars heltal var, och praktiskt nog är nästan alla tecken som används vardagligen av den typen. De flesta tecken som kräver två 16-bitars heltal är sällsynta kinesiska tecken, sällsynta symboler, tecken från utdöda språk och emoji. Vi kommer att bortse från sådana tecken i den här kursen.}
 
 \Subtask Vad ger följande jämförelser för värde?
 \begin{REPL}


### PR DESCRIPTION
The original text was ambiguous (are comparisons done by code point or code value?). This commit adds a footnote so that those who want to find out more can get an accurate definition of comparison in Scala/Java. The idea of the footnote is to point out that supplementary characters exist and may need to be handled in a special way, while not going into the details of how supplementary characters are encoded. The linked Wikipedia page describes the details (and also explains a little about Unicode and its history, unlike the equivalent page on Swedish Wikipedia).