### PR TITLE
Add hyphenation hints for last names of authors

### DIFF
--- a/contributors.tex
+++ b/contributors.tex
@@ -5,6 +5,7 @@
 %    This work is licenced under CC-BY-SA-4.0.
 %!TEX encoding = UTF-8 Unicode
 %!TEX root = compendium/compendium.tex
+\hyphenation{Borg-lund Da-ne-bjer Grampp Palm-qvist Ravn-borg Ro-sen-qvist Schrei-ter Wih-lan-der}
 \emph{Contributors} in alphabetical order:
 Anders Buhl,
 Anna Axelsson,


### PR DESCRIPTION
The author list hyphenated Palmqvist as Pal-mqvist instead of the correct Palm-qvist. This commit fixes that, and also fixes missing and incorrect hyphenations that currently aren't used but might be used if the layout is altered.