### PR TITLE
Replace W3Schools links

### DIFF
--- a/compendium/modules/w13-exercise.tex
+++ b/compendium/modules/w13-exercise.tex
@@ -423,11 +423,7 @@ Hur stora tal klarar din server nu? Vad händer med servern när minnet tar slut
 
 \Task Fördjupa dig inom webbteknologi. 
     
-\Subtask Lär dig om HTML här: \url{http://www.w3schools.com/html/}
-
-\Subtask Lär dig om Javascript här: \url{http://www.w3schools.com/js/}
-
-\Subtask Lär dig om CSS här: \url{http://www.w3schools.com/css/}
+\Subtask Lär dig om HTML, CSS och JavaScript här: \url{https://developer.mozilla.org/en-US/docs/Learn}
 
 \Subtask Lär dig om Scala.JS här: \url{http://www.scala-js.org/}
 


### PR DESCRIPTION
W3Schools is not often regarded as a good resource, so I'm replacing the links to it with a link to the more respected MDN (Mozilla Development Network).