### PR TITLE
Added "Build URL" for compendium

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is work in progress; the first instance of the course starts this fall seme
 
 ## How to use this repo
 
-* Download the latest version of the [compendium](https://github.com/lunduniversity/introprog/raw/master/compendium/compendium.pdf).
+* Download the latest version of the compendium via [LaTeX.Online](https://latexonline.cc/compile?git=https://github.com/lunduniversity/introprog&target=compendium/compendium.tex&command=pdflatex).
 
 * Download the [workspace](https://github.com/lunduniversity/introprog/blob/master/lib/workspace.zip) to be used with your favorite code editor and IDE. See instructions in appendices in the compendium.
 


### PR DESCRIPTION
Hi everyone,

I noticed that the link to PDF version of compendium is not working and I updated it.

Basically, the link I added is something we call "Build URL" - each time it's visited, [latexonline.cc](https://latexonline.cc) will fetch all TeX files from the repository (if they were updated) and create the PDF. You won’t need to re-generate PDF each time its sources are updated. And if there are no updates, the service will return cached version.

We recently updated latexonline.cc to be more convenient for the users and I thought your repository is a good example where the service will be useful.

Let me know what you think.