### PR TITLE
Reword w06 footnote about Swedish sorting

### DIFF
--- a/compendium/modules/w06-sequences-exercise.tex
+++ b/compendium/modules/w06-sequences-exercise.tex
@@ -585,7 +585,7 @@ case class Person(förnamn: String, efternamn: String)
 val ps = Vector(Person("Kim","Ung"), Person("kamrat", "Clementin"))
 \end{Code}
 Deklarera ovan i REPL och para ihop uttryck nedan med rätt resultat.
-\\\emph{Tips:} Stora bokstäver sorteras före små bokstäver i den inbyggda ordningen för grundtyperna \code{String} och \code{Char}. Dessutom har svenska tecken knasig ordning.\footnote{En kvarleva från föråldrade teckenkodningsstandarder:    \url{https://sv.wikipedia.org/wiki/ASCII}}
+\\\emph{Tips:} Stora bokstäver sorteras före små bokstäver i den inbyggda ordningen för grundtyperna \code{String} och \code{Char}. Dessutom har svenska tecken knasig ordning.\footnote{Ordningen kommer ursprungligen från föråldrade teckenkodningsstandarder:    \url{https://sv.wikipedia.org/wiki/ASCII}}
 \\Läs om sorteringsmetoderna i snabbreferensen och prova i REPL.
 
 \begin{ConceptConnections}


### PR DESCRIPTION
That Swedish letters don't sort as expected is not just because of historical reasons – it is impossible to have one sorting order that's correct for all languages, so even if we were to make a new order, it'll be wrong for some amount of languages no matter what. As an example, Ö is the last letter of the alphabet in Swedish, but German places it earlier in the alphabet, so making the order correct for Swedish would make it wrong for German.

(Of course, it's possible to write programs that select different sorting orders depending on e.g. a language setting, but this part of the compendium is about the "built-in" order that Char has.)