### PR TITLE
Fix chapter 1 task 6 (chessboard grains)

### DIFF
--- a/compendium/modules/w01-intro-exercise.tex
+++ b/compendium/modules/w01-intro-exercise.tex
@@ -252,7 +252,7 @@ res4: Int = -2147483648
 
 \Task \what
 
-\Subtask Antag att du har ett schackbräde med 64 rutor. Tänk dig att du börjar med ett enda riskorn på första rutan och sedan lägger dubbelt så många riskorn i en ny hög för varje efterföljande ruta: 1, 2, 4, 8, ...  etc. Hur många riskorn\footnote{\url{https://en.wikipedia.org/wiki/Wheat_and_chessboard_problem}} blir det då i den sextiofjärde rishögen?
+\Subtask Antag att du har ett schackbräde med 64 rutor. Tänk dig att du börjar med att lägga ett enda riskorn på första rutan och sedan lägger dubbelt så många riskorn i en ny hög för varje efterföljande ruta: 1, 2, 4, 8, ...  etc. När du har gjort detta för alla rutor, hur många riskorn har du totalt lagt på schackbrädet?\footnote{\url{https://en.wikipedia.org/wiki/Wheat_and_chessboard_problem}}
 
 \emph{Tips:} Du ska beräkna $2^{64} - 1$. Om du skriver \code{math.} i REPL och trycker TAB får du se inbyggda matematiska funktioner i Scalas standardbibliotek:
 \begin{REPL}


### PR DESCRIPTION
The way that the compendium is worded right now, it's asking for the amount of grains in the 64th square, but both the answer (2^64 - 1) and the Wikipedia article are about the total amount of grains.

@bjornregnell This is the problem that I mentioned very briefly earlier today.