### PR TITLE
Course Instructions - Fixing link

### DIFF
--- a/compendium/prechapters/course-instructions.tex
+++ b/compendium/prechapters/course-instructions.tex
@@ -27,7 +27,7 @@ Samarbetsgrupperna organiserar själva sitt arbete och varje grupp får finna de
 
 Ni ska upprätta ett samarbetskontrakt redan under första veckan och visa för en handledare. Alla gruppmedlemmarna ska skriva under kontraktet. Handledaren ska också skriva under som bekräftelse på att ni visat kontraktet.
 
-Syftet med kontraktet är att ni ska diskutera igenom i gruppen hur ni vill arbeta och vilka regler ni tycker är rimliga. Ni bestämmer själva vad kontraktet ska innehålla. Nedan finns förslag på punkter som kan ingå i ert kontrakt. En kontraktsmall finns här: \url{https://github.com/lunduniversity/introprog/blob/master/admin/collaboration-contract.tex}
+Syftet med kontraktet är att ni ska diskutera igenom i gruppen hur ni vill arbeta och vilka regler ni tycker är rimliga. Ni bestämmer själva vad kontraktet ska innehålla. Nedan finns förslag på punkter som kan ingå i ert kontrakt. En kontraktsmall finns här: \url{https://github.com/lunduniversity/introprog/blob/master/study-groups/collaboration-contract.tex}
 
 \begin{tcolorbox}%[width=1.05\textwidth,  grow to right by=0.03\textwidth,grow to left by=0.03\textwidth,breakable, enhanced]
 \subsubsection*{Samarbetskontrakt}


### PR DESCRIPTION
Fixing the link for the study-group contract example, so it works correctly.