### PR TITLE
Change of unclear params in randomWalk

### DIFF
--- a/compendium/modules/w01-intro-lab.tex
+++ b/compendium/modules/w01-intro-lab.tex
@@ -213,7 +213,7 @@ for (???) {???}
 \end{figure}
 
 
-\Subtask Skriv en procedur \code{def randomWalk(n: Int, step: Int, angle: Int) = ???} som gör så att paddan tar \code{n} steg av slumpmässig längd mellan \code{0} och \code{step}, samt efter varje steg vrider sig åt vänster en slumpmässig vinkel mellan \code{0} och \code{angle}. Anropa din procedur med olika argument och undersök hur dess värden påverkar bildens utseende. \emph{Tips:} Uttrycket \code{math.random * 100} ger ett tal från 0 till (nästan) 100. Du kan styra hur långsamt paddan ritar genom anrop av \code{sakta(???)} (prova dig fram till något  lämpligt heltalsargument i stället för \code{???}).
+\Subtask Skriv en procedur \code{def randomWalk(n: Int, maxStep: Int, maxAngle: Int) = ???} som gör så att paddan tar \code{n} steg av slumpmässig längd mellan \code{0} och \code{maxStep}, samt efter varje steg vrider sig åt vänster en slumpmässig vinkel mellan \code{0} och \code{maxAngle}. Anropa din procedur med olika argument och undersök hur dess värden påverkar bildens utseende. \emph{Tips:} Uttrycket \code{math.random * 100} ger ett tal från 0 till (nästan) 100. Du kan styra hur långsamt paddan ritar genom anrop av \code{sakta(???)} (prova dig fram till något  lämpligt heltalsargument i stället för \code{???}).
 \vspace{2em}\\\includegraphics[width=\textwidth]{../img/kojo/random-walk.png}
 
 


### PR DESCRIPTION
The method `randomWalk(n: Int, step: Int, angle: Int)` could confuse the student because of the variables `step` and `angle` that could be re-used by the student in the method.
Instead i recommend `maxStep` and `maxAngle` as params for `randomWalk`-method to eliminate the confusion.