### PR TITLE
Fixed subtle bug in testShuffle()

### DIFF
--- a/workspace/w06_shuffle/src/main/scala/cards/TestDeck.scala
+++ b/workspace/w06_shuffle/src/main/scala/cards/TestDeck.scala
@@ -16,6 +16,7 @@ object TestDeck {
     val deck = Deck(testCards)
     for (i <- 1L to n) {
       if (i % 1e6.toLong == 0L) print(".")
+      deck.reset()
       deck.shuffle()
       val permIndex = perms.indexOf(deck.toVector)
       freq(permIndex) += 1L


### PR DESCRIPTION
TestDeck.testShuffle() contained a small bug whereby biased (but complete) shuffles would show as even