### PR TITLE
bank: Remove addAccount and removeAccount from spec

### DIFF
--- a/compendium/modules/w13-assignment-bank.tex
+++ b/compendium/modules/w13-assignment-bank.tex
@@ -128,18 +128,6 @@ abstract class BankEvent {
  */
 class Bank() = {
 
-  /**
-   * Adds a new account in the bank.
-   * The account number generated for the account is returned.
-   */
-  def addAccount(name: String, id: Int): Int = ???
-
- /**
-   * Removes the bank account with provided account number.
-   * Returns true if successful, otherwise false is returned.
-   */
-  def removeAccount(accountNbr: Int): Boolean = ???
-
  /**
    * Returns a list of every bank account in the bank.
    * The returned list is sorted in alphabetical order based


### PR DESCRIPTION
There are only two reasonable ways to implement these two methods, and neither is good design:

1. Both methods create a BankEvent and call doEvent. This would be reasonable behavior, but then why are there such methods for creating/removing accounts but not for depositing/withdrawing/transferring money?

2. Both methods modify the state directly without creating a BankEvent. In this case, the methods must not be called by anything other than doEvent, so they should not be public.