### PR TITLE
Prevent column breaks in bank examples in a more robust way

### DIFF
--- a/compendium/modules/w13-assignment-bank.tex
+++ b/compendium/modules/w13-assignment-bank.tex
@@ -283,9 +283,16 @@ Ditt program måste inte se identiskt ut, men den övergripande strukturen såv�
 När det första exemplet börjar förutsätts det att banken inte har några konton.
 
 Listan över val, som är markerad i kursiv stil i det första exemplet, är inte utskriven i senare exempel för att spara plats på pappret. Ditt program ska alltid skriva ut listan över val före användaren ska mata in ett val.
+
+% This environment uses minipage to prevent column breaks from occurring in the middle of an example
+\newenvironment{exampleblock}
+	{\begin{minipage}{\columnwidth}
+	 - - - - - - - - - - - - - - - - - - - - - - - - - - -\\}
+	{\end{minipage}}
+
 \begin{multicols}{2}
 \noindent
-- - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
+\begin{exampleblock}
 \textit{
 1.   Hitta ett konto för en given kund\\*
 2.   Sök efter kunder på (del av) namn\\*
@@ -303,68 +310,80 @@ Namn: \textbf{Adam Asson}\\*
 Id: \textbf{6707071234}\\*
 Nytt konto skapat med kontonummer: 1000\\*
 10:03:0 CET 14 / 5 - 2016\\
-- - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
+\end{exampleblock}
+\begin{exampleblock}
 Val: \textbf{1}\\*
 Id: \textbf{6707071234}\\*
 Konto 1000 (Adam Asson, id 6707071234) 0 kr\\*
 10:04:0 CET 14 / 5 - 2016\\
-- - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
+\end{exampleblock}
+\begin{exampleblock}
 Val: \textbf{6}\\*
 Namn: \textbf{Berit Besson}\\*
 Id: \textbf{8505255678}\\*
 Nytt konto skapat med kontonummer: 1001\\*
 10:12:0 CET 14 / 5 - 2016\\
-- - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
+\end{exampleblock}
+\begin{exampleblock}
 Val: \textbf{2}\\*
 Namn: \textbf{adam}\\*
 Adam Asson, id 6707071234\\*
 10:15:0 CET 14 / 5 - 2016\\
-- - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
+\end{exampleblock}
+\begin{exampleblock}
 Val: \textbf{8}\\*
 Konto 1000 (Adam Asson, id 6707071234) 0 kr\\*
 Konto 1001 (Berit Besson, id 8505255678) 0 kr\\*
 10:13:0 CET 14 / 5 - 2016\\
-- - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
+\end{exampleblock}
+\begin{exampleblock}
 Val: \textbf{6}\\*
 Namn: \textbf{Berit Besson}\\*
 Id: \textbf{8505255678}\\*
 Nytt konto skapat med kontonummer: 1002\\*
 13:56:0 CET 14 / 5 - 2016\\
-- - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
+\end{exampleblock}
+\begin{exampleblock}
 Val: \textbf{2}\\*
 Namn: \textbf{erit}\\*
 Berit Besson, id 8505255678\\*
 14:01:0 CET 14 / 5 - 2016\\
-- - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
+\end{exampleblock}
+\begin{exampleblock}
 Val: \textbf{3}\\*
 Kontonummer: \textbf{1000}\\*
 Summa: \textbf{5000}\\*
 Transaktionen lyckades.\\*
 14:36:0 CET 14 / 5 - 2016\\
-- - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
+\end{exampleblock}
+\begin{exampleblock}
 Val: \textbf{5}\\*
 Kontonummer att överföra ifrån: \textbf{1000}\\*
 Kontonummer att överföra till: \textbf{1001}\\*
 Summa: \textbf{1000}\\*
 Transaktionen lyckades.\\*
 14:37:0 CET 14 / 5 - 2016\\
-- - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
+\end{exampleblock}
+\begin{exampleblock}
 Val: \textbf{8}\\*
 Konto 1000 (Adam Asson, id 6707071234) 4000 kr\\*
 Konto 1001 (Berit Besson, id 8505255678) 1000 kr\\*
 Konto 1002 (Berit Besson, id 8505255678) 0 kr\\*
 14:52:0 CET 14 / 5 - 2016\\
-- - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
+\end{exampleblock}
+\begin{exampleblock}
 Val: \textbf{7}\\*
 Ange konto att radera: \textbf{1002}\\*
 Transaktionen lyckades.\\*
 14:01:0 CET 14 / 5 - 2016\\
-- - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
+\end{exampleblock}
+\begin{exampleblock}
 Val: \textbf{8}\\*
 Konto 1000 (Adam Asson, id 6707071234) 4000 kr\\*
 Konto 1001 (Berit Besson, id 8505255678) 1000 kr\\*
 14:01:0 CET 14 / 5 - 2016\\
-- - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
+\end{exampleblock}
+\begin{exampleblock}
 Val: \textbf{9}\\*
 Vilket datum vill du återställa banken till?\\*
 År: \textbf{2016}\\*
@@ -374,7 +393,8 @@ Timme: \textbf{18}\\*
 Minut: \textbf{10}\\*
 Banken återställd.\\*
 15:00:0 CET 14 / 5 - 2016\\
-- - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
+\end{exampleblock}
+\begin{exampleblock}
 Val: \textbf{8}\\*
 Konto 1002 (Björn, id 651002) 25900 kr\\*
 Konto 1001 (Casper, id 900318) 4600 kr\\*
@@ -382,10 +402,13 @@ Konto 1003 (Eva, id 950908) 6300 kr\\*
 Konto 1000 (Fredrik, id 850127) 11800 kr\\*
 Konto 1004 (Kajsa, id 810722) 17000 kr\\*
 15:01:0 CET 14 / 5 - 2016\\
-- - - - - - - - - - - - - - - - - - - - - - - - - - -\\*
+\end{exampleblock}
+\begin{exampleblock}
 Val: \textbf{3}\\*
 Kontonummer: \textbf{1005}\\*
 Summa: \textbf{5000}\\*
 Transaktionen misslyckades. Inget sådant konto hittades.\\*
 15:06:0 CET 14 / 5 - 2016\\
+\end{exampleblock}
+
 \end{multicols}

--- a/compendium/modules/w13-assignment-bank.tex
+++ b/compendium/modules/w13-assignment-bank.tex
@@ -294,120 +294,120 @@ Listan över val, som är markerad i kursiv stil i det första exemplet, är int
 \noindent
 \begin{exampleblock}
 \textit{
-1.   Hitta ett konto för en given kund\\*
-2.   Sök efter kunder på (del av) namn\\*
-3.   Sätt in pengar\\*
-4.   Ta ut pengar\\*
-5.   Överför pengar mellan konton\\*
-6.   Skapa nytt konto\\*
-7.   Radera existerande konto\\*
-8.   Skriv ut alla konton i banken\\*
-9.   Återställ banken till ett tidigare datum\\*
-10.  Avsluta\\*
+1.   Hitta ett konto för en given kund\\
+2.   Sök efter kunder på (del av) namn\\
+3.   Sätt in pengar\\
+4.   Ta ut pengar\\
+5.   Överför pengar mellan konton\\
+6.   Skapa nytt konto\\
+7.   Radera existerande konto\\
+8.   Skriv ut alla konton i banken\\
+9.   Återställ banken till ett tidigare datum\\
+10.  Avsluta\\
 }
-Val: \textbf{6}\\*
-Namn: \textbf{Adam Asson}\\*
-Id: \textbf{6707071234}\\*
-Nytt konto skapat med kontonummer: 1000\\*
+Val: \textbf{6}\\
+Namn: \textbf{Adam Asson}\\
+Id: \textbf{6707071234}\\
+Nytt konto skapat med kontonummer: 1000\\
 10:03:0 CET 14 / 5 - 2016\\
 \end{exampleblock}
 \begin{exampleblock}
-Val: \textbf{1}\\*
-Id: \textbf{6707071234}\\*
-Konto 1000 (Adam Asson, id 6707071234) 0 kr\\*
+Val: \textbf{1}\\
+Id: \textbf{6707071234}\\
+Konto 1000 (Adam Asson, id 6707071234) 0 kr\\
 10:04:0 CET 14 / 5 - 2016\\
 \end{exampleblock}
 \begin{exampleblock}
-Val: \textbf{6}\\*
-Namn: \textbf{Berit Besson}\\*
-Id: \textbf{8505255678}\\*
-Nytt konto skapat med kontonummer: 1001\\*
+Val: \textbf{6}\\
+Namn: \textbf{Berit Besson}\\
+Id: \textbf{8505255678}\\
+Nytt konto skapat med kontonummer: 1001\\
 10:12:0 CET 14 / 5 - 2016\\
 \end{exampleblock}
 \begin{exampleblock}
-Val: \textbf{2}\\*
-Namn: \textbf{adam}\\*
-Adam Asson, id 6707071234\\*
+Val: \textbf{2}\\
+Namn: \textbf{adam}\\
+Adam Asson, id 6707071234\\
 10:15:0 CET 14 / 5 - 2016\\
 \end{exampleblock}
 \begin{exampleblock}
-Val: \textbf{8}\\*
-Konto 1000 (Adam Asson, id 6707071234) 0 kr\\*
-Konto 1001 (Berit Besson, id 8505255678) 0 kr\\*
+Val: \textbf{8}\\
+Konto 1000 (Adam Asson, id 6707071234) 0 kr\\
+Konto 1001 (Berit Besson, id 8505255678) 0 kr\\
 10:13:0 CET 14 / 5 - 2016\\
 \end{exampleblock}
 \begin{exampleblock}
-Val: \textbf{6}\\*
-Namn: \textbf{Berit Besson}\\*
-Id: \textbf{8505255678}\\*
-Nytt konto skapat med kontonummer: 1002\\*
+Val: \textbf{6}\\
+Namn: \textbf{Berit Besson}\\
+Id: \textbf{8505255678}\\
+Nytt konto skapat med kontonummer: 1002\\
 13:56:0 CET 14 / 5 - 2016\\
 \end{exampleblock}
 \begin{exampleblock}
-Val: \textbf{2}\\*
-Namn: \textbf{erit}\\*
-Berit Besson, id 8505255678\\*
+Val: \textbf{2}\\
+Namn: \textbf{erit}\\
+Berit Besson, id 8505255678\\
 14:01:0 CET 14 / 5 - 2016\\
 \end{exampleblock}
 \begin{exampleblock}
-Val: \textbf{3}\\*
-Kontonummer: \textbf{1000}\\*
-Summa: \textbf{5000}\\*
-Transaktionen lyckades.\\*
+Val: \textbf{3}\\
+Kontonummer: \textbf{1000}\\
+Summa: \textbf{5000}\\
+Transaktionen lyckades.\\
 14:36:0 CET 14 / 5 - 2016\\
 \end{exampleblock}
 \begin{exampleblock}
-Val: \textbf{5}\\*
-Kontonummer att överföra ifrån: \textbf{1000}\\*
-Kontonummer att överföra till: \textbf{1001}\\*
-Summa: \textbf{1000}\\*
-Transaktionen lyckades.\\*
+Val: \textbf{5}\\
+Kontonummer att överföra ifrån: \textbf{1000}\\
+Kontonummer att överföra till: \textbf{1001}\\
+Summa: \textbf{1000}\\
+Transaktionen lyckades.\\
 14:37:0 CET 14 / 5 - 2016\\
 \end{exampleblock}
 \begin{exampleblock}
-Val: \textbf{8}\\*
-Konto 1000 (Adam Asson, id 6707071234) 4000 kr\\*
-Konto 1001 (Berit Besson, id 8505255678) 1000 kr\\*
-Konto 1002 (Berit Besson, id 8505255678) 0 kr\\*
+Val: \textbf{8}\\
+Konto 1000 (Adam Asson, id 6707071234) 4000 kr\\
+Konto 1001 (Berit Besson, id 8505255678) 1000 kr\\
+Konto 1002 (Berit Besson, id 8505255678) 0 kr\\
 14:52:0 CET 14 / 5 - 2016\\
 \end{exampleblock}
 \begin{exampleblock}
-Val: \textbf{7}\\*
-Ange konto att radera: \textbf{1002}\\*
-Transaktionen lyckades.\\*
+Val: \textbf{7}\\
+Ange konto att radera: \textbf{1002}\\
+Transaktionen lyckades.\\
 14:01:0 CET 14 / 5 - 2016\\
 \end{exampleblock}
 \begin{exampleblock}
-Val: \textbf{8}\\*
-Konto 1000 (Adam Asson, id 6707071234) 4000 kr\\*
-Konto 1001 (Berit Besson, id 8505255678) 1000 kr\\*
+Val: \textbf{8}\\
+Konto 1000 (Adam Asson, id 6707071234) 4000 kr\\
+Konto 1001 (Berit Besson, id 8505255678) 1000 kr\\
 14:01:0 CET 14 / 5 - 2016\\
 \end{exampleblock}
 \begin{exampleblock}
-Val: \textbf{9}\\*
-Vilket datum vill du återställa banken till?\\*
-År: \textbf{2016}\\*
-Månad: \textbf{5}\\*
-Datum (dag): \textbf{9}\\*
-Timme: \textbf{18}\\*
-Minut: \textbf{10}\\*
-Banken återställd.\\*
+Val: \textbf{9}\\
+Vilket datum vill du återställa banken till?\\
+År: \textbf{2016}\\
+Månad: \textbf{5}\\
+Datum (dag): \textbf{9}\\
+Timme: \textbf{18}\\
+Minut: \textbf{10}\\
+Banken återställd.\\
 15:00:0 CET 14 / 5 - 2016\\
 \end{exampleblock}
 \begin{exampleblock}
-Val: \textbf{8}\\*
-Konto 1002 (Björn, id 651002) 25900 kr\\*
-Konto 1001 (Casper, id 900318) 4600 kr\\*
-Konto 1003 (Eva, id 950908) 6300 kr\\*
-Konto 1000 (Fredrik, id 850127) 11800 kr\\*
-Konto 1004 (Kajsa, id 810722) 17000 kr\\*
+Val: \textbf{8}\\
+Konto 1002 (Björn, id 651002) 25900 kr\\
+Konto 1001 (Casper, id 900318) 4600 kr\\
+Konto 1003 (Eva, id 950908) 6300 kr\\
+Konto 1000 (Fredrik, id 850127) 11800 kr\\
+Konto 1004 (Kajsa, id 810722) 17000 kr\\
 15:01:0 CET 14 / 5 - 2016\\
 \end{exampleblock}
 \begin{exampleblock}
-Val: \textbf{3}\\*
-Kontonummer: \textbf{1005}\\*
-Summa: \textbf{5000}\\*
-Transaktionen misslyckades. Inget sådant konto hittades.\\*
+Val: \textbf{3}\\
+Kontonummer: \textbf{1005}\\
+Summa: \textbf{5000}\\
+Transaktionen misslyckades. Inget sådant konto hittades.\\
 15:06:0 CET 14 / 5 - 2016\\
 \end{exampleblock}
 


### PR DESCRIPTION
The old way of doing it only prevented column breaks between lines, not column breaks in the middle of lines.