### PR TITLE
bank: Improve date formatting

### DIFF
--- a/compendium/modules/w13-assignment-bank.tex
+++ b/compendium/modules/w13-assignment-bank.tex
@@ -252,52 +252,52 @@ Val: \textbf{6}\\
 Namn: \textbf{Adam Asson}\\
 Id: \textbf{6707071234}\\
 Nytt konto skapat med kontonummer: 1000\\
-10:03:0 CET 14 / 5 - 2016\\
+10:03 14/5-2016\\
 \end{exampleblock}
 \begin{exampleblock}
 Val: \textbf{1}\\
 Id: \textbf{6707071234}\\
 Konto 1000 (Adam Asson, id 6707071234) 0 kr\\
-10:04:0 CET 14 / 5 - 2016\\
+10:04 14/5-2016\\
 \end{exampleblock}
 \begin{exampleblock}
 Val: \textbf{6}\\
 Namn: \textbf{Berit Besson}\\
 Id: \textbf{8505255678}\\
 Nytt konto skapat med kontonummer: 1001\\
-10:12:0 CET 14 / 5 - 2016\\
+10:12 14/5-2016\\
 \end{exampleblock}
 \begin{exampleblock}
 Val: \textbf{8}\\
 Konto 1000 (Adam Asson, id 6707071234) 0 kr\\
 Konto 1001 (Berit Besson, id 8505255678) 0 kr\\
-10:13:0 CET 14 / 5 - 2016\\
+10:13 14/5-2016\\
 \end{exampleblock}
 \begin{exampleblock}
 Val: \textbf{2}\\
 Namn: \textbf{adam}\\
 Adam Asson, id 6707071234\\
-10:15:0 CET 14 / 5 - 2016\\
+10:15 14/5-2016\\
 \end{exampleblock}
 \begin{exampleblock}
 Val: \textbf{6}\\
 Namn: \textbf{Berit Besson}\\
 Id: \textbf{8505255678}\\
 Nytt konto skapat med kontonummer: 1002\\
-13:56:0 CET 14 / 5 - 2016\\
+13:56 14/5-2016\\
 \end{exampleblock}
 \begin{exampleblock}
 Val: \textbf{2}\\
 Namn: \textbf{erit}\\
 Berit Besson, id 8505255678\\
-14:01:0 CET 14 / 5 - 2016\\
+14:01 14/5-2016\\
 \end{exampleblock}
 \begin{exampleblock}
 Val: \textbf{3}\\
 Kontonummer: \textbf{1000}\\
 Summa: \textbf{5000}\\
 Transaktionen lyckades.\\
-14:36:0 CET 14 / 5 - 2016\\
+14:36 14/5-2016\\
 \end{exampleblock}
 \begin{exampleblock}
 Val: \textbf{5}\\
@@ -305,36 +305,36 @@ Kontonummer att överföra ifrån: \textbf{1000}\\
 Kontonummer att överföra till: \textbf{1001}\\
 Summa: \textbf{1000}\\
 Transaktionen lyckades.\\
-14:37:0 CET 14 / 5 - 2016\\
+14:37 14/5-2016\\
 \end{exampleblock}
 \begin{exampleblock}
 Val: \textbf{8}\\
 Konto 1000 (Adam Asson, id 6707071234) 4000 kr\\
 Konto 1001 (Berit Besson, id 8505255678) 1000 kr\\
 Konto 1002 (Berit Besson, id 8505255678) 0 kr\\
-14:52:0 CET 14 / 5 - 2016\\
+14:52 14/5-2016\\
 \end{exampleblock}
 \begin{exampleblock}
 Val: \textbf{7}\\
 Ange konto att radera: \textbf{1002}\\
 Transaktionen lyckades.\\
-14:54:0 CET 14 / 5 - 2016\\
+14:54 14/5-2016\\
 \end{exampleblock}
 \begin{exampleblock}
 Val: \textbf{8}\\
 Konto 1000 (Adam Asson, id 6707071234) 4000 kr\\
 Konto 1001 (Berit Besson, id 8505255678) 1000 kr\\
-14:55:0 CET 14 / 5 - 2016\\
+14:55 14/5-2016\\
 \end{exampleblock}
 \begin{exampleblock}
 Val: \textbf{9}\\
-10:03:0 CET 14 / 5 - 2016: Skapade ett konto tillhörandes Adam Asson, id 6707071234\\
-10:12:0 CET 14 / 5 - 2016: Skapade ett konto tillhörandes Berit Besson, id 8505255678\\
-13:56:0 CET 14 / 5 - 2016: Skapade ett konto tillhörandes Berit Besson, id 8505255678\\
-14:36:0 CET 14 / 5 - 2016: Satte in 5000 kr i konto 1000\\
-14:37:0 CET 14 / 5 - 2016: Överförde 1000 kr från konto 1000 till konto 1001\\
-14:54:0 CET 14 / 5 - 2016: Raderade konto 1002\\
-14:58:0 CET 14 / 5 - 2016\\
+10:03 14/5-2016: Skapade ett konto tillhörandes Adam Asson, id 6707071234\\
+10:12 14/5-2016: Skapade ett konto tillhörandes Berit Besson, id 8505255678\\
+13:56 14/5-2016: Skapade ett konto tillhörandes Berit Besson, id 8505255678\\
+14:36 14/5-2016: Satte in 5000 kr i konto 1000\\
+14:37 14/5-2016: Överförde 1000 kr från konto 1000 till konto 1001\\
+14:54 14/5-2016: Raderade konto 1002\\
+14:58 14/5-2016\\
 \end{exampleblock}
 \begin{exampleblock}
 Val: \textbf{10}\\
@@ -345,31 +345,31 @@ Datum (dag): \textbf{14}\\
 Timme: \textbf{10}\\
 Minut: \textbf{5}\\
 Banken återställd.\\
-15:00:0 CET 14 / 5 - 2016\\
+15:00 14/5-2016\\
 \end{exampleblock}
 \begin{exampleblock}
 Val: \textbf{9}\\
-10:03:0 CET 14 / 5 - 2016: Skapade ett konto tillhörandes Adam Asson, id 6707071234\\
-15:00:0 CET 14 / 5 - 2016\\
+10:03 14/5-2016: Skapade ett konto tillhörandes Adam Asson, id 6707071234\\
+15:00 14/5-2016\\
 \end{exampleblock}
 \begin{exampleblock}
 Val: \textbf{8}\\
 Konto 1000 (Adam Asson, id 6707071234) 0 kr\\
-15:01:0 CET 14 / 5 - 2016\\
+15:01 14/5-2016\\
 \end{exampleblock}
 \begin{exampleblock}
 Val: \textbf{3}\\
 Kontonummer: \textbf{1001}\\
 Summa: \textbf{5000}\\
 Transaktionen misslyckades. Inget sådant konto hittades.\\
-15:06:0 CET 14 / 5 - 2016\\
+15:06 14/5-2016\\
 \end{exampleblock}
 \begin{exampleblock}
 Val: \textbf{4}\\
 Kontonummer: \textbf{1000}\\
 Summa: \textbf{1000}\\
 Transaktionen misslyckades. Otillräckligt saldo.\\
-15:23:0 CET 14 / 5 - 2016\\
+15:23 14/5-2016\\
 \end{exampleblock}
 
 \end{multicols}

--- a/workspace/w13_bank_proj/src/main/scala/bank/time/Date.scala
+++ b/workspace/w13_bank_proj/src/main/scala/bank/time/Date.scala
@@ -3,6 +3,7 @@
 package bank.time
 
 import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 /**
  * Creates a Date object based on date given as parameters.
@@ -10,21 +11,22 @@ import java.time.LocalDateTime
 case class Date(year: Int, month: Int, dayOfMonth: Int, hour: Int, minute: Int) {
   private val calendar = LocalDateTime.of(year, month, dayOfMonth, hour, minute)
 
+  private def toFormat(format: String): String = calendar.format(DateTimeFormatter.ofPattern(format))
+
   /**
    * A short string showing the day and month
    */
-  lazy val toShortFormat: String = "" + calendar.getDayOfMonth + "/" + (calendar.getMonth)
+  lazy val toShortFormat: String = toFormat("d/M")
 
   /**
    * A string suitable for writing to log files
    */
-  lazy val toLogFormat: String = calendar.getYear + " " + calendar.getMonthValue + " " + calendar.getDayOfMonth + " " + calendar.getHour + " " + calendar.getMinute
+  lazy val toLogFormat: String = toFormat("yyyy M d H m")
 
   /**
    * A string suitable for showing to users
    */
-  lazy val toNaturalFormat: String = calendar.getHour + ":" + calendar.getMinute + ":" + calendar.getSecond + " CET " + calendar.getDayOfMonth + " / " +
-        calendar.getMonthValue + " - " + calendar.getYear
+  lazy val toNaturalFormat: String = toFormat("HH:mm d/M-yyyy")
 
   /**
    * Checks whether this date happened before, at the same time as or after the provided date.


### PR DESCRIPTION
This change improves the "natural format" of Dates:

- Hours and minutes have leading zeroes
- Seconds aren't shown since they always are stored as 0
- Extra spaces are removed
- "CET" is removed - it was hardcoded rather than providing actual info

The formatting code is also made a bit neater.