### PR TITLE
Store personnummer as Long in w09

### DIFF
--- a/compendium/modules/w09-inheritance-exercise.tex
+++ b/compendium/modules/w09-inheritance-exercise.tex
@@ -225,7 +225,7 @@ Skapa instanser av de nya case-klasserna \code{Student} och \code{Forskare} och 
 
 Man inför också en case-klass \code{IckeAkademiker} som man tänker använda i olika statistiska medborgarundersökningar.
 
-Dessutom förser man alla personer med ett personnummer representerat som en \code{Int}.
+Dessutom förser man alla personer med ett personnummer representerat som en \code{Long}.
 
 Hur ser utbildningsdepartementets kod ut nu, efter alla ändringar? Skriv ett testprogram som skapar några instanser och skriver ut deras attribut.
 
@@ -259,21 +259,21 @@ toString för Forskare: Student(Person4,LTH,Doktorand).
 
 \SubtaskSolved
 \begin{Code}
-trait Person {val namn: String; val nbr: Int}
+trait Person {val namn: String; val nbr: Long}
 trait Akademiker extends Person {val universitet: String}
 case class Student(
   namn: String,
-  nbr: Int,
+  nbr: Long,
   universitet: String,
   program: String) extends Akademiker
 case class Forskare(
   namn: String,
-  nbr: Int,
+  nbr: Long,
   universitet: String,
   titel: String) extends Akademiker
 case class IckeAkademiker(
     namn: String,
-    nbr: Int) extends Person
+    nbr: Long) extends Person
 \end{Code}
 
 \SubtaskSolved  Man måste använda en klass om man behöver klassparametrar. Man måste använda en trait om man vill göra in-mixning med \code{with}. \\


### PR DESCRIPTION
This is the same problem as the bank project had last year: 32-bit integers are a bit too small for storing 10-digit numbers.