### PR TITLE
Correct facts about MIDI synthesizers

### DIFF
--- a/compendium/modules/w10-patterns-lab.tex
+++ b/compendium/modules/w10-patterns-lab.tex
@@ -159,7 +159,7 @@ Ett exempel på ett gitarrackord  visas i figur \ref{music:fig:guitar-chord}.
 
 Ett elektroniskt instrument syntetiserar ljud med hjälp av analog och/eller digital elektronik, och kallas därför \textbf{synthesizer}, ofta förkortat \emph{synt} \Eng{synth}.
 
-I JDK ingår ett api för att styra syntar. De flesta moderna datorer har ljudkort med inbyggd synt som följer den så kallade MIDI-standarden. Java-paketet \code{javax.sound.midi} innehåller klasser som kan få ett sådant ljudkort att spela musik med hjälp av MIDI.
+De flesta moderna PC-operativsystem inkluderar mjukvaruimplementerade syntar som följer den så kallade MIDI-standarden. Java-paketet \code{javax.sound.midi} innehåller klasser som kan få en sådan MIDI-synt att spela musik.
 
 MIDI-standarden baseras på en modell av ett pianotangentbord där olika toner kan vara ''på'' eller ''av'' beroende på om en tangent är nedtryckt eller ej. Dessa toners höjd är modellerade på samma sätt som i vår klass \code{Pitch}, där alltså tonhöjden \code{60} motsvarar tonen \code{"C5"}, etc. En tangent kan tryckas ner olika hårt, vilket representeras av ett heltalsvärde i \code{Range(0,128)} kallat \code{velocity}. Ett högt värde ger en stark ton, medan ett litet värde motsvarar en svag (tyst) ton.
 


### PR DESCRIPTION
The majority of modern computers do not have sound cards that include hardware synthesizers. That was only really popular during the 90s. For the reference, Microsoft added a software synthesizer in Windows 98 and removed support for hardware synthesizers in Windows Vista.