### PR TITLE
Edit w10 Excersice 19

### DIFF
--- a/compendium/modules/w10-patterns-exercise.tex
+++ b/compendium/modules/w10-patterns-exercise.tex
@@ -1057,7 +1057,7 @@ Vad ger metoden \code{##} i scala.Any för resultat? Läs dokumentationen här: 
 
 \Task \label{task:equals:Complex} \what~   Nedan visas delar av klassen \code{Complex} som representerar ett komplext tal med realdel och imaginärdel. I stället för att, som man ofta gör i Scala, använda en case-klass och en \code{equals}-metod som automatiskt ger innehållslikhet, ska du träna på att implementera en egen \code{equals}.
 \begin{Code}
-class Complex(re: Double, im: Double) {
+class Complex(val re: Double, val im: Double) {
   def abs: Double = math.hypot(re, im)
   override def toString = s"Complex($re, $im)"
   def canEqual(other: Any): Boolean = ???


### PR DESCRIPTION
Eftersom medlemmarna re och im är privata fungerar inte den föreslagna lösningen i punkt 6. kompilatorn ger felmeddelandet " error: value im is not a member of Complex". Om man däremot gör medlemmarna publika eller kör en case class istället för en vanlig class så försvinner problemet

  override def equals(other: Any): Boolean = {
    other match{
      case that: Complex => (that canEqual this) && (that.re == this.re) && (that.im == this.im)
      case _ => false
    }
  }