### PR TITLE
Update Synth.scala in lab w10_music 

### DIFF
--- a/workspace/w10_music/src/main/scala/music/Synth.scala
+++ b/workspace/w10_music/src/main/scala/music/Synth.scala
@@ -26,7 +26,11 @@ object Synth {
     val found = sortedInstruments.filter(key =>
       containing.forall(s => key.toLowerCase.contains(s.toLowerCase))
     )
-    found.map(instrIndex).toVector
+
+    if(found.isEmpty)
+      findInstrumentIndicesByName("piano")
+    else
+      found.map(instrIndex).toVector
   }
 
   def changeInstrument(index: Int, channel: Int = 0): Unit = {
@@ -39,7 +43,7 @@ object Synth {
     changeInstrument(firstInstrumentFound, channel)
   }
 
-  lazy val defaultInstruments = Vector("grand","guit","bass","trump","flute")
+  lazy val defaultInstruments = Vector("piano","guit","bass","trump","flute")
 
   def resetInstruments(): Unit = defaultInstruments.zipWithIndex.foreach {
     case (nameContains, channel) => changeInstrumentByName(nameContains, channel)


### PR DESCRIPTION
Changed first default instrument from grand to piano to reflect instrument names on Windows. The program will still find grand piano on Mac and Linux. 

Added if statement on line 30. In case no instruments are found fall back to piano.

This change has been tested on my Windows computer, a Mac and the Linux computers in the basement of the E building.
