### PR TITLE
Update Synth.scala music lab

### DIFF
--- a/workspace/w10_music/src/main/scala/music/Synth.scala
+++ b/workspace/w10_music/src/main/scala/music/Synth.scala
@@ -35,8 +35,10 @@ object Synth {
   }
 
   def changeInstrumentByName(containing: String, channel: Int = 0): Unit = {
-    val firstInstrumentFound = findInstrumentIndicesByName(containing).head
-    changeInstrument(firstInstrumentFound, channel)
+    findInstrumentIndicesByName(containing).headOption match {
+      case Some(instrument) => changeInstrument(instrument, channel)
+      case None => println("Instrument containing \""+ containing + "\" not found")
+    }
   }
 
   lazy val defaultInstruments = Vector("grand","guit","bass","trump","flute")


### PR DESCRIPTION
Neither "grand" nor "guit" is found on Windows 10 (maybe other versions of Windows as well). The grand piano is probably one of the instruments containing "piano" and the guitars contains "gt".

Because there might be a system where the instrument is called something different, it is impossible to completely fix this issue, so that it will always play the correct sound by default on every channel on every system with the current implementation of Synth.resetInstruments().

What the code does is just ignoring the instruments (in Synth.defaultInstruments) that it cannot find, which means that the default sound (piano probably) will be played on those channels instead. This means that this fix is allowing you to complete the lab, but with the wrong sounds (channel 1 is piano sound instead of guitar sound for example) (I cannot find anywhere it use another channel than 0 anyway). You can change them by either editing Synth.defaultInstruments to something that exists, or by calling Synth.changeInstrumentByName.