### PR TITLE
bank: Fix missing menu choice and wrongly numbered menu choice

### DIFF
--- a/compendium/modules/w13-assignment-bank.tex
+++ b/compendium/modules/w13-assignment-bank.tex
@@ -196,7 +196,7 @@ Till din hjälp innehåller kursens workspace de färdigskrivna klasserna \code{
 
 \Subtask När programmet startar ska det läsa in alla händelser från historikfilen och återuppspela dem en efter en. På så sätt kan bankens tillstånd återställas, fastän vi bara har sparat ändringshistoriken och inte själva tillståndet. Använd \code{fromLogString}-metoden i \code{HistoryEntry} när du läser in strängar från filen.
 
-\Task Implementera menyval 9 genom att först nollställa bankens tillstånd och sedan återuppspela allt i historiken som hände före det givna datumet. Resten av historiken bör tas bort permanent, både i minnet och i historikfilen.
+\Task Implementera menyval 10 genom att först nollställa bankens tillstånd och sedan återuppspela allt i historiken som hände före det givna datumet. Resten av historiken bör tas bort permanent, både i minnet och i historikfilen.
 
 
 \subsection{Frivilliga extrauppgifter}
@@ -245,8 +245,9 @@ Listan över val, som är markerad i kursiv stil i det första exemplet, är int
 6.   Skapa nytt konto\\
 7.   Radera existerande konto\\
 8.   Skriv ut alla konton i banken\\
-9.   Återställ banken till ett tidigare datum\\
-10.  Avsluta\\
+9.   Skriv ut ändringshistoriken\\
+10.  Återställ banken till ett tidigare datum\\
+11.  Avsluta\\
 }
 Val: \textbf{6}\\
 Namn: \textbf{Adam Asson}\\


### PR DESCRIPTION
The menu choice for printing the history was missing from the example printout, and task 6 wrongly said to implement choice 9 instead of choice 10.

To clarify, the intent was to implement history printing in task 4b) and to implement history rollback in task 6.