### PR TITLE
Remove trailing comma exercise

### DIFF
--- a/compendium/modules/w07-setmap-exercise.tex
+++ b/compendium/modules/w07-setmap-exercise.tex
@@ -172,8 +172,6 @@ Metoden \code{->} fungerar med alla typer och är en fabriksmetod för par. Meto
   \end{tabular}
 \end{table}
 
-\Subtask Vad blir det för felmeddelande om du råkar skriva ett komma för mycket före den avslutande högerparentesen: ...\code{und",)}
-
 \Subtask Skriv ett uttryck som plockar fram \code{"Lund"} ur \code{huvudstad}.
 
 \SOLUTION
@@ -204,17 +202,6 @@ val huvudstad = Vector(
   "Skåne"    -> "Lund"
 )
 \end{Code}
-
-\SubtaskSolved
-
-\begin{REPL}
-scala> Vector("Sverige"->"Stockholm","Norge"->"Oslo","Skåne"->"Lund",)
-<console>:1: error: illegal start of simple expression
-\end{REPL}
-Man skriver ofta en mappning per rad för att det ska gå att läsa som en tabell, och inte som ovan med alla mappningar på samma rad.
-
-Det är lätt hänt att få med ett komma för mycket (eller för lite) när man flyttar eller duplicerar rader med många mappningar i en kodeditor. I en framtida version av Scala kommer sådana problem att vara mindre smärtsamma:\\
-\url{http://docs.scala-lang.org/sips/completed/trailing-commas.html}
 
 \SubtaskSolved
 \begin{REPL}


### PR DESCRIPTION
Trailing commas are supported in the version of Scala that we're using, so this task doesn't make sense anymore. Fixes #300.