### PR TITLE
Replace references to SimpleWindow with PixelWindow

### DIFF
--- a/plan/Plan.scala
+++ b/plan/Plan.scala
@@ -61,7 +61,7 @@ trait Plan {
       | namnrymd, synlighet, privat medlem, inkapsling,
       | getter och setter, principen om uniform access,
       | överlagring av metoder,
-      | cslib.window.SimpleWindow,
+      | introprog.PixelWindow,
       | initialisering, lazy val,
       | värdeandrop, namnanrop,
       | typalias,

--- a/slides/body/lect-w13-exam-tips.tex
+++ b/slides/body/lect-w13-exam-tips.tex
@@ -120,7 +120,7 @@ Funktioner    & definiera, anropa, parameter, argument  & skapa kontrollstruktur
 \textbf{Modul} & \textit{Ingår t.ex.}& \textit{Avgränsning} (ej krav; kan hjälpa)\\\hline
 Objekt      & singelobjekt, attribut, medlem, metod, & isInstanceOf (anv. match istället) \\
             & tillstånd, synlighet, skuggning, block, & scaladoc, javadoc, jar \\
-            & punktnotation, namnrymd,  & paket, import, SimpleWindow \\
+            & punktnotation, namnrymd,  & paket, import, PixelWindow \\
             & lazy val, io.Source.fromFile  &  \\
             & tupler, multipla returvärden &  \\
 \hline


### PR DESCRIPTION
There are still some references left in lectures and the imageprocessing lab, but those can be dealt with later.