### PR TITLE
Consistency fixes in chapter 5's exercises

### DIFF
--- a/compendium/modules/w05-classes-exercise.tex
+++ b/compendium/modules/w05-classes-exercise.tex
@@ -398,7 +398,7 @@ res9: blockbattle.Pos = Pos(0,2)
 %   /** Om keyControl.has(key) så uppdateras riktningen dir enligt keyControl */
 %   def setDir(key: String): Unit = ???
 %
-%   /** Uppdaterar dir till motsatta riktningen. */
+%   /** Uppdaterar dir till motsatta riktningen */
 %   def reverseDir(): Unit = ???
 %
 %   /** Uppdaterar pos så att den blir nextPos */

--- a/compendium/modules/w05-classes-exercise.tex
+++ b/compendium/modules/w05-classes-exercise.tex
@@ -208,7 +208,7 @@ case class Pt(x: Int = 0, y: Int = 0) {
 class MutablePt(private var p: (Int, Int) = (0, 0)) {
   def x: Int = p._1
   def y: Int = p._2
-  def move(dx: Int = 0, dy: Int = 0) = { p = (x + dx, y+ dy); this }
+  def move(dx: Int = 0, dy: Int = 0) = { p = (x + dx, y + dy); this }
   override def toString = s"MPt($x,$y)"
 }
 \end{Code}
@@ -380,7 +380,7 @@ res9: blockbattle.Pos = Pos(0,2)
 \end{REPL}
 
 
-\Subtask Gör klart case-klassen \code{Mole} enligt nedan. Mole är en klass som representerar en blockmullvad med föränderliga attribut för position, riktning och poäng. Varje instans har även oföränderliga attribut som håller reda på dess namn, dess färg och vilka tangenter som kan användas för att styra mullvaden. Implementera klassens medlemmar en i taget och testa noga med lämpliga testfall efter varje tillägg/buggfix. Skapa ett huvudprogram t.ex. i filen \code{Main.scala} med dina tester som skapar instanser och skriver ut attribut etc. När du kör \code{~run} i sbt så kommer huvudprogrammet att automatiskt köras om efter automatisk omkompilering av de ändrade delarna varje gång du sparar någon \code{.scala}-fil.
+\Subtask Gör klart klassen \code{Mole} enligt nedan. Mole är en klass som representerar en blockmullvad med föränderliga attribut för position, riktning och poäng. Varje instans har även oföränderliga attribut som håller reda på dess namn, dess färg och vilka tangenter som kan användas för att styra mullvaden. Implementera klassens medlemmar en i taget och testa noga med lämpliga testfall efter varje tillägg/buggfix. Skapa ett huvudprogram t.ex. i filen \code{Main.scala} med dina tester som skapar instanser och skriver ut attribut etc. När du kör \code{~run} i sbt så kommer huvudprogrammet att automatiskt köras om efter automatisk omkompilering av de ändrade delarna varje gång du sparar någon \code{.scala}-fil.
 \scalainputlisting[basicstyle=\ttfamily\fontsize{10}{12}\selectfont]{../workspace/w05_blockbattle/Mole.scala}
 % \begin{CodeSmall}
 % class Mole(


### PR DESCRIPTION
Use more consistent spacing in Exercise 5's `def move.`
Don't refer to Mole as a case-class when it has no case prefix in the example/template code.