### PR TITLE
Correct typo in w07 lecture slides

### DIFF
--- a/slides/body/lect-w07-collections.tex
+++ b/slides/body/lect-w07-collections.tex
@@ -193,7 +193,7 @@ nycklarna är alltså \Alert{unika}.
 \begin{itemize}
 \item En \Emph{nyckel-värde-tabell} \Eng{key-value table} är en slags generaliserad vektor där man kan ''indexera'' med godtycklig typ.
 
-\item Kallas öven \href{https://sv.wikipedia.org/wiki/Hashtabell}{\Emph{hashtabell}} \Eng{hash table}, \Emph{lexikon} \Eng{dictionary} eller \Emph{mapp} \Eng{map} (men då blir det lätt sammanblandning med metoden \code{map}).
+\item Kallas även \href{https://sv.wikipedia.org/wiki/Hashtabell}{\Emph{hashtabell}} \Eng{hash table}, \Emph{lexikon} \Eng{dictionary} eller \Emph{mapp} \Eng{map} (men då blir det lätt sammanblandning med metoden \code{map}).
 
 \item Om man vet nyckeln kan man slå upp värdet \Alert{snabbt}, på liknande sätt som indexering sker i en vektor om man vet heltalsindex.
 


### PR DESCRIPTION
Corrects a small typo in the lecture slides for week 7 (collections).