### PR TITLE
Remove redundant step from Lab 7 Exercise 4 instructions 

### DIFF
--- a/compendium/modules/w07-setmap-lab.tex
+++ b/compendium/modules/w07-setmap-lab.tex
@@ -102,8 +102,7 @@ res2: Map[String,Int] = Map(10292 -> 1, 19125 -> 1, 26985 -> 1, 29301 -> 1, 5451
 \Task \emph{Dela upp en sträng i ord}. Du ska implementera medlemmen \code{words}. Den ska innehålla en vektor med alla ord i \code{source}, utan andra tecken än bokstäver.
 Detta åstadkommer du genom att utgå ifrån strängen \code{source} och i tur och ordning göra följande:
 \begin{enumerate}%[nolistsep, noitemsep]
-\item byta ut alla tecken i \code{source} för vilka \code{isWhitespace} är sant mot \code{' '}
-\item byta sedan ut alla tecken för vilka \code{isLetter} är falskt mot \code{' '}
+\item byta ut alla tecken i \code{source} för vilka \code{isLetter} är falskt mot \code{' '}
 \item dela upp strängen från föregående steg i en array av strängar med \code{split(' ')}
 \item filtrera bort alla tomma strängar
 \item gör om alla bokstäver i alla strängar till små bokstäver


### PR DESCRIPTION
In [Lab 7 exercise 4](https://github.com/lunduniversity/introprog/blob/master/compendium/modules/w07-setmap-lab.tex#L102-L111), the [first step](https://github.com/lunduniversity/introprog/blob/master/compendium/modules/w07-setmap-lab.tex#L105) - to replace any `whitespace` characters with a space (`' '`) - is made redundant by the [second step](https://github.com/lunduniversity/introprog/blob/master/compendium/modules/w07-setmap-lab.tex#L106) - to replace any non-letter characters with a space (`' '`).

The reasoning behind this is that there are, as far as I understand, no (16-bit) characters that pass the test of being both a whitespace- and letter-character. All whitespace characters are "non-letter characters". 

```scala
scala> (Char.MinValue to Char.MaxValue).find(c => c.toChar.isLetter && c.toChar.isWhitespace)
res1: Option[Char] = None
```

In other words, any character that matches `_.isWhitespace` will also match `!_.isLetter`, and replacing all `!_.isLetter` characters is hence sufficient.

---

This PR fixes #379. See issue for a more detailed explanation of the problem.