### PR TITLE
Add myself to the contributors list

### DIFF
--- a/contributors.tex
+++ b/contributors.tex
@@ -1,7 +1,7 @@
 %  LIST OF CONTRIBUTORS to https://github.com/lunduniversity/introprog
-%    Please contact bjorn.regnell@cs.lth.se if you think you should be 
-%    on this list, or make a pull request with an update of file briefly 
-%    describing your contribtion in the commit text. 
+%    Please contact bjorn.regnell@cs.lth.se if you think you should be
+%    on this list, or make a pull request with an update of file briefly
+%    describing your contribtion in the commit text.
 %    This work is licenced under CC-BY-SA-4.0.
 %!TEX encoding = UTF-8 Unicode
 %!TEX root = compendium/compendium.tex
@@ -38,7 +38,7 @@ Simon Persson,
 Stefan Jonsson,
 Tim Borglund,
 Tom Postema,
-Valthor Halldorsson, 
+Valthor Halldorsson,
 Viktor Claesson,
 Wilhelm Wanecek,
 William Karlsson.

--- a/contributors.tex
+++ b/contributors.tex
@@ -40,4 +40,5 @@ Tim Borglund,
 Tom Postema,
 Valthor Halldorsson, 
 Viktor Claesson,
+Wilhelm Wanecek,
 William Karlsson.


### PR DESCRIPTION
Feels a bit lite patting my own shoulder, but... It's fun. Thanks for the offer @bjornregnell :smile: 

Thought: Would be pretty cool to generate this from the [contributors page](https://github.com/lunduniversity/introprog/graphs/contributors) with [GitHub's API](https://developer.github.com/v3/repos/#list-contributors) :) Either with Travis, or with GitHub's new Actions :thinking: 

**But** that could also lead to people getting their name in the book without them wanting to... Maybe not worth overengineering it 