### PR TITLE
Formatting: premature closing of code block

### DIFF
--- a/compendium/modules/w08-matrices-exercise.tex
+++ b/compendium/modules/w08-matrices-exercise.tex
@@ -187,7 +187,7 @@ res18: String =
 
 
 \Subtask Implementera funktionen \\
-\code{def yatzyPips(xss: Vector[Vector[Int]]): Vector[Int]} = ???\\
+\code{def yatzyPips(xss: Vector[Vector[Int]]): Vector[Int] = ???}\\
 som ska ge en vektor med de tärningsvärden som gav yatzy, för kasten i matrisen \code{xss} enligt nedan. Använd din funktion \code{filterYatzy}.
 \begin{REPL}
 scala> val dm = Vector(Vector(1,2,3,4,5),Vector(4,4,4,4,4),Vector(3,3,3,3,3))


### PR DESCRIPTION
Fix a small formatting bug causing the last bit of a code-block not to use a monospaced font. 

So instead of:
![screenshot-2018-11-06t11 19 18](https://user-images.githubusercontent.com/1533747/48058089-e01b0f00-e1b5-11e8-89be-4241c30e5d67.png)
It looked like:
![screenshot-2018-11-06t11 19 25](https://user-images.githubusercontent.com/1533747/48058090-e01b0f00-e1b5-11e8-876d-4cc6ede1c166.png)

---

Let's be honest, this is just silly procastination from my side. 