### PR TITLE
Remove unnecssary new before case class instantiation

### DIFF
--- a/workspace/w09_snake/src/main/scala/snake/pairs.scala
+++ b/workspace/w09_snake/src/main/scala/snake/pairs.scala
@@ -27,7 +27,7 @@ object Pos {
   import scala.util.Random
 
   def apply(x: Int, y: Int, dim: Dim): Pos =
-    new Pos(mod(x, dim.x), mod(y, dim.y), dim)
+    Pos(mod(x, dim.x), mod(y, dim.y), dim)
 
   def random(dim: Dim): Pos = {
     Pos(Random.nextInt(dim.x), Random.nextInt(dim.y), dim)


### PR DESCRIPTION
As far as I can tell, the `new` keyword is redundant here, as we're instantiating a case class. Instead, it's confusing for those unsure of when to use `new` and when it can be omitted.

---

Found by @claracyon :tada: