### PR TITLE
Typo in w11 exercise instructions

### DIFF
--- a/compendium/modules/w11-scalajava-exercise.tex
+++ b/compendium/modules/w11-scalajava-exercise.tex
@@ -101,7 +101,7 @@ import java.util.{HashSet => JHashSet};
 
 \item I metoden \code{hideSecret}, använd \code{map} i stället för en \code{for}-sats.
 
-\item Det går att ersätta metoden \code{findAll} med det kärnfulla uttrycket \\ \code{(secret forall found)} där \code{secret} är en sträng och \code{found} är en mängd av tecken (undersök gärna i REPL hur detta fungerar). Skippa därför den metoden helt och använd det kortare uttrycket direkt.
+\item Det går att ersätta metoden \code{foundAll} med det kärnfulla uttrycket \\ \code{(secret forall found)} där \code{secret} är en sträng och \code{found} är en mängd av tecken (undersök gärna i REPL hur detta fungerar). Skippa därför den metoden helt och använd det kortare uttrycket direkt.
 
 \item I metoden \code{makeGuess}, i stället för \code{Scanner}, använd \code{scala.io.StdIn.readLine}.
 


### PR DESCRIPTION
A small typo/misreference in the exercise instructions of week 11. The instructions refer to a `findAll` method, which is probably meant to be `foundAll` :man_shrugging: 