### PR TITLE
Avoid use of .recover in scalajava/hangman2 example

### DIFF
--- a/compendium/examples/scalajava/hangman2.scala
+++ b/compendium/examples/scalajava/hangman2.scala
@@ -26,9 +26,6 @@ object hangman {
       val words = fromURL(address, coding).getLines.toVector
       val rnd = (math.random * words.size).toInt
       words(rnd)
-    }.recover{ case e: Exception =>  
-      println(s"Error: $e")
-      "lackalänga"
     }.toOption
 
   def play(secret: String): Unit = {
@@ -52,7 +49,8 @@ object hangman {
   def main(args: Array[String] ): Unit = {
     if (args.length == 0) {
       val runeberg = "http://runeberg.org/words/ord.ortsnamn.posten"
-      download(runeberg, "ISO-8859-1").foreach(play)
+      val secret = download(runeberg, "ISO-8859-1").getOrElse("läckalånga")
+      play(secret)
     } else play(args((math.random * args.length).toInt))
   }  
 }

--- a/compendium/modules/w11-scalajava-exercise.tex
+++ b/compendium/modules/w11-scalajava-exercise.tex
@@ -111,7 +111,7 @@ import java.util.{HashSet => JHashSet};
 
 \item Låt metoden \code{download} returnera en \code{Option[String]} som i fallet att nedladdningen misslyckas returnerar \code{None}.
 
-\item I metoden \code{download}, i stället för \code{try}-\code{catch} använd \code{scala.util.Try} och dess smidiga metoder \code {recover} och \code{toOption}.
+\item I metoden \code{download}, i stället för \code{try}-\code{catch} använd \code{scala.util.Try} och dess smidiga metod \code{toOption}.
 
 \item Om du vill träna på att använda rekursion i stället för imperativa loopar: Använd, i stället för \code{while}-satsen i metoden \code{play}, en lokal rekursiv funktion med denna signatur:
 \begin{Code}


### PR DESCRIPTION
## What

Let `download` directly convert the result of the Try-block to an option, forcing the callee to handle the error instead of providing a fallback case (and println) inside the download method.

**Note:** This _does_ introduce an inconsistency with `hangman1.scala` and `Hangman.java`, as these both `println` an error if such occurs. Not sure if that's relevant, I'll let you be the judge @bjornregnell.

## Why

Hopefully less confusing to others

## How

- Remove lines with `.recover{...}`
- Handle result with `Option#getOrElse`
- Update module .tex description (_This was the only place I could find that explicitly mentions the previous format, and I tried my best with some grepping of the `compendium/` directory, with words such as `download`, `läckalånga`, and `recover`. Would be great if someone could verify that I didn't miss anything this._)

---

This issue fixes #390 