### PR TITLE
Fixed a regex to split commands in tabular labb

### DIFF
--- a/workspace/w10_tabular/src/main/scala/tabular/Command.scala
+++ b/workspace/w10_tabular/src/main/scala/tabular/Command.scala
@@ -29,7 +29,7 @@ object Command {
    def fromUser(): Vector[String] = {
      // readLine can give null if Ctrl+D is typed by user (Linux, MacOS)
      val cmdOpt = Option(scala.io.StdIn.readLine("> ")) // None if null
-     cmdOpt.map(_.split(' ').map(_.trim).toVector).getOrElse(Vector("quit"))
+     cmdOpt.map(s => """"[^"]+"|[^\s]+""".r.findAllMatchIn(s).toVector.map(s => s.toString().replace("\"","")).map(_.trim)).getOrElse(Vector("quit"))
    }
 
    def TODO = "TODO: Not yet implemented."


### PR DESCRIPTION

Fixes #392 

Added a regex match instead of the simple split(' ') command in fromUser()

The command is however quite hard to understand so if we do not want to expose the stundents to regex it might be better to keep older version.