### PR TITLE
Use lowercase key names in KeyControl exercise

### DIFF
--- a/compendium/modules/w05-classes-exercise.tex
+++ b/compendium/modules/w05-classes-exercise.tex
@@ -303,7 +303,7 @@ res0: Int = 1
 
 \QUESTBEGIN
 
-\Task\label{exe:classes:labprep}  \what~I nästa laboration ska du bygga vidare på \code{blockmole}-labben och göra ett spel för två spelare där varje spelare styr sin \emph{egen} instans av en \code{blockmole}. Vi måste då göra om \code{Mole} så att den blir en klass i stället för ett singelobjekt. Gör färdigt klasserna nedan och testa noggrant så att de fungerar. Alla klasser ska tillhöra \code{package blockbattle} och ligga i varsin egen fil med samma namn som klassen, t.ex. \code{Pos.scala}. När du har mer än en kodfil som du vill kompilera om upprepade gånger vid stegvis implementation och felsökning, underlättas ditt arbetet stort om du använder byggverktyget \code{sbt} som finns installerat på skolans datorer (se även Appendix~\ref{appendix:build}). Lägg en fil med namnet \code{build.sbt} i biblioteket där du jobbar t.ex. \code{~/pgk/w05/lab} med detta innehåll:
+\Task\label{exe:classes:labprep}  \what~I nästa laboration ska du bygga vidare på \code{blockmole}-labben och göra ett spel för två spelare där varje spelare styr sin \emph{egen} instans av en \code{blockmole}. Vi måste då göra om \code{Mole} så att den blir en klass i stället för ett singelobjekt. Gör färdigt klasserna nedan och testa noggrant så att de fungerar. Alla klasser ska tillhöra \code{package blockbattle} och ligga i varsin egen fil med samma namn som klassen, t.ex. \code{Pos.scala}. När du har mer än en kodfil som du vill kompilera om upprepade gånger vid stegvis implementation och felsökning, underlättas ditt arbetet stort om du använder byggverktyget \code{sbt} som finns installerat på skolans datorer (se även Appendix~\ref{appendix:build}). Lägg en fil med namnet \code{build.sbt} i biblioteket där du jobbar t.ex. \code{~/pgk/w06/lab} med detta innehåll:
 \begin{Code}
 scalaVersion := "2.12.9"
 \end{Code}
@@ -317,7 +317,7 @@ sbt> ~compile
 \scalainputlisting[basicstyle=\ttfamily\fontsize{11}{13}\selectfont]{../workspace/w06_blockbattle/Pos.scala}
 Om du använder \code{sbt} hamnar den kompilerade koden i \code{target/scala-2.12/classes}. Testa så att \code{Pos} fungerar med hjälp av REPL enligt nedan:
 \begin{REPL}
-> cd ~/pgk/w05/lab
+> cd ~/pgk/w06/lab
 > scala -cp target/scala-2.12/classes
 Welcome to Scala 2.12.9 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_171).
 Type in expressions for evaluation. Or try :help.
@@ -348,8 +348,8 @@ res1: blockbattle.Pos = Pos(1,3)
 scala> import blockbattle._
 import blockbattle._
 
-scala> val kc1 = KeyControl(right="D",left="A",up="W",down="S")
-kc1: blockbattle.KeyControl = KeyControl(A,D,W,S)
+scala> val kc1 = KeyControl(right="d",left="a",up="w",down="s")
+kc1: blockbattle.KeyControl = KeyControl(a,d,w,s)
 
 scala> val kc2 = KeyControl("Left","Right","Up","Down")
 kc2: blockbattle.KeyControl = KeyControl(Left,Right,Up,Down)
@@ -357,25 +357,25 @@ kc2: blockbattle.KeyControl = KeyControl(Left,Right,Up,Down)
 scala> kc2.left
 res2: String = Left
 
-scala> kc2.has("A")
+scala> kc2.has("a")
 res3: Boolean = false
 
 scala> kc2.has("Up")
 res4: Boolean = true
 
-scala> kc1.direction("A")
+scala> kc1.direction("a")
 res5: (Int, Int) = (-1,0)
 
-scala> kc1.direction("S")
+scala> kc1.direction("s")
 res6: (Int, Int) = (0,1)
 
-scala> kc1.direction("D")
+scala> kc1.direction("d")
 res7: (Int, Int) = (1,0)
 
-scala> kc1.direction("W")
+scala> kc1.direction("w")
 res8: (Int, Int) = (0,-1)
 
-scala> Pos(1,2).moved(kc1.direction("A"))
+scala> Pos(1,2).moved(kc1.direction("a"))
 res9: blockbattle.Pos = Pos(0,2)
 \end{REPL}
 


### PR DESCRIPTION
Using uppercase key names in the REPL example might lead to some confusion during the blockbattle lab, since PixelWindow uses lowercase key names.