### PR TITLE
Update introprog-scalalib version number to 1.1.4

### DIFF
--- a/compendium/global-constants.tex
+++ b/compendium/global-constants.tex
@@ -1,4 +1,4 @@
-\newcommand{\LibVersion}{1.1.3} % latest version of introlib at https://github.com/lunduniversity/introprog-scalalib
+\newcommand{\LibVersion}{1.1.4} % latest version of introlib at https://github.com/lunduniversity/introprog-scalalib
 \newcommand{\LibJar}{\texttt{introprog-\LibVersion.jar}}
 \newcommand{\JDKApiUrl}{\url{https://docs.oracle.com/javase/8/docs/api/}}
 \newcommand{\CurrentYear}{2019}


### PR DESCRIPTION
Many places still referred to 1.1.3.

Signed-off-by: Jakob Sinclair <sinclair.jakob@mailbox.org>