### PR TITLE
"Primitiva Array" should be plural

### DIFF
--- a/slides/body/lect-w11-scalajava.tex
+++ b/slides/body/lect-w11-scalajava.tex
@@ -617,7 +617,7 @@ object Person {
 
 \Subsection{Array}
 
-\begin{Slide}{Repetition: Primitiva Array i JVM}
+\begin{Slide}{Repetition: Den primitiva typen Array i JVM}
 \begin{itemize}
 \item Primitiva arrayer (\code{Array} i Scala, \code{[]} i Java) har \Emph{fördelar}:%
 \footnote{\href{http://stackoverflow.com/questions/2843928/benefits-of-arrays}{stackoverflow.com/questions/2843928/benefits-of-arrays}}


### PR DESCRIPTION
This matches the text under it: "Primitiva arrayer".

An alternative could be: "Primitiv Array"

Signed-off-by: Jakob Sinclair <sinclair.jakob@mailbox.org>