### PR TITLE
Fix incorrect indexing in week 6 slides

### DIFF
--- a/slides/body/lect-w06-exceptions.tex
+++ b/slides/body/lect-w06-exceptions.tex
@@ -104,12 +104,12 @@ scala> def försök = Try { kanskePang }
 
 scala> val xs = Vector.fill(15){försök}
 
-scala> val trettonde = xs(13) match {
+scala> val trettonde = xs(12) match {
          case Success(value) => value
          case Failure(e) => println(e); -1
        }
 
-scala> (xs(13).isSuccess, xs(13).isFailure)
+scala> (xs(12).isSuccess, xs(12).isFailure)
 
 scala> försök.foreach(println)
 


### PR DESCRIPTION
The thirteenth element of xs is at index 12, not 13. 