### PR TITLE
Fix references to old library code

### DIFF
--- a/compendium/modules/w04-objects-exercise.tex
+++ b/compendium/modules/w04-objects-exercise.tex
@@ -609,9 +609,9 @@ case PixelWindow.Event.KeyPressed => println("lastKey == " + w.lastKey)
 
 \SubtaskSolved När pil-upp-knappen på tangentbordet trycks ned får \code{w.lastKey} strängvärdet \code{"Up"}. Följande skrivs ut av testprogrammet när pil-upp-tangenten trycks ned och släpps upp:
 \begin{REPL}
-lastEventType == KeyPressed
+lastEventType: 1 => KeyPressed
 lastKey == Up
-lastEventType == KeyReleased
+lastEventType: 2 => KeyReleased
 lastKey == Up
 \end{REPL}
 

--- a/compendium/modules/w04-objects-exercise.tex
+++ b/compendium/modules/w04-objects-exercise.tex
@@ -584,7 +584,7 @@ object Main {
 \Task \what~På veckans laboration ska du implementera ett enkelt spel där användaren kan styra en blockmullvad med tangentbordet. Med \code{introprog.PixelWindow} kan du hantera de händelser som genereras när användaren trycker ner eller släpper en tangent eller en musknapp.
 
 
-\Subtask Studera dokumentationen för singelobjektet \code{introprog.PixelWindow.Event}. Vad heter den oföränderliga strängvariabel som representerar att en nedtryckning av en tangentbordsknapp har inträffat? Vad har strängen för värde?
+\Subtask Studera dokumentationen för singelobjektet \code{introprog.PixelWindow.Event}. Vad heter den oföränderliga heltalsvariabel som representerar att en nedtryckning av en tangentbordsknapp har inträffat? Vad har variabeln för värde?
 
 \Subtask Via dokumentationen för av singelobjektet \code{introprog.examples.TestPixelWindow} kan du komma åt koden som implementerar objektet genom att klicka på länken \code{Source} ovanför sökrutan. Vilken rad i huvudprogrammet i \code{main}-metoden tar hand om fallet att en knappnedtryckningshändelse har inträffat?
 
@@ -600,7 +600,7 @@ där \code{X.Y.Z} ska bytas mot aktuell version. Ett testfönster öppnas när \
 
 \TaskSolved \what~
 
-\SubtaskSolved Den oföränderliga strängvariablen \code{KeyPressed} i \code{introprog.PixelWindow.Event} har värdet \code{"KeyPressed"}.
+\SubtaskSolved Den oföränderliga heltalsvariabeln \code{KeyPressed} i \code{introprog.PixelWindow.Event} har värdet \code{1}.
 
 \SubtaskSolved Kodraden nedan tar hand om knappnedtryckningsfallet:
 \begin{Code}


### PR DESCRIPTION
The text was referring to String-variables in introprog.PixelWindow.Event, which have been refactored to Int-variables (introprog-0.1.1). Also along with this change the REPL-output of introprog.examples.TestPixelWindow changed.