### PR TITLE
Fix #475 added missing definition for r

### DIFF
--- a/compendium/modules/w02-programs-exercise.tex
+++ b/compendium/modules/w02-programs-exercise.tex
@@ -1355,7 +1355,7 @@ res3: Double = 288.6589258453995
 
 \begin{REPL}
 scala> val intervall = (1 to Int.MaxValue by 2)
-scala> val sekvens = r.toArray
+scala> val sekvens = intervall.toArray
 \end{REPL}
 \emph{Tips:} Använd uttrycket \code{ BigInt(Int.MaxValue) * 2 } i dina beräkningar.
 


### PR DESCRIPTION
Fix for #475, the missing defintion for r has been added, based on the answer in chapter L.2.3.