### PR TITLE
fix bug in blockmole 11.c

### DIFF
--- a/compendium/modules/w04-objects-lab.tex
+++ b/compendium/modules/w04-objects-lab.tex
@@ -338,10 +338,10 @@ Skapa en ny metod \code{BlockWindow.keepOnDigging} som från början är en kopi
 
 \item Anropa \code{waitForKeyNonBlocking} i stället för \code{waitForKey} och kolla efter knapptryckning enligt nedan kodskelett. Fyll i de saknade delarna så att blockmullvaden rör sig ett steg i rätt riktning i varje looprunda.
 \begin{Code}
-      if      (key == 'w') { dy = -1; dx = 0 }
-      else if (key == 'a') { ??? }
-      else if (key == 's') { ??? }
-      else if (key == 'd') { ??? }
+      if      (key == "w") { dy = -1; dx = 0 }
+      else if (key == "a") { ??? }
+      else if (key == "s") { ??? }
+      else if (key == "d") { ??? }
       else if (key == "q") { quit = true }
       y += ???
       x += ???


### PR DESCRIPTION
`keepOnDigging()` should check if `key` is of type `String`, not of type `Char`.