### PR TITLE
fix typo "BlockWindow.keepOnDigging" 

### DIFF
--- a/compendium/modules/w04-objects-lab.tex
+++ b/compendium/modules/w04-objects-lab.tex
@@ -329,7 +329,7 @@ Lägg till en ny metod \code{BlockWindow.delay} som ska göra det möjligt att h
 
 
 \Subtask
-Skapa en ny metod \code{BlockWindow.keepOnDigging} som från början är en kopia av metoden \code{dig}. Gör följande tillägg/ändringar:
+Skapa en ny metod \code{Mole.keepOnDigging} som från början är en kopia av metoden \code{dig}. Gör följande tillägg/ändringar:
 \begin{enumerate}[nolistsep,noitemsep]
 
 \item Lägg till två variabler \code{var dx} och \code{var dy} i början, som ska hålla reda på riktningen som blockmullvaden gräver. Initialisera dem till \code{0} respektive {1}.


### PR DESCRIPTION
fix a typo in the instructions, according to the lab solutions