### PR TITLE
fix typo new Mole.move() in lab w06

### DIFF
--- a/compendium/modules/w06-patterns-lab.tex
+++ b/compendium/modules/w06-patterns-lab.tex
@@ -103,7 +103,7 @@ Du ska implementera minst ett (gärna flera) av dessa krav:
   \item Beskriv vilka åtgärder du gjort för att din kod ska vara lätt att läsa och förstå.
   \item Beskriv hur du stegvis utvecklat ditt program från enklare till mer avancerad funktionalitet, samt vilka buggar du upptäckt och fixat.
   \item Beskriv vilket eller vilka valfria krav som din implementation uppfyller.
-  \item Beskriv hur du hade behövt ändra i klassen \code{Mole} för att det ska gå att skriva \code{new Mole.move().move().reverseDir().move()}
+  \item Beskriv hur du hade behövt ändra i klassen \code{Mole} för att det ska gå att skriva \code{new Mole().move().move().reverseDir().move()}
 \end{itemize}
 
 \subsection{Tips och förslag}


### PR DESCRIPTION
move() is probably not meant to be static, and new Mole.move() should be fixed accordingly.