### PR TITLE
Fix outdated info in answer for exercise 7 task 5

### DIFF
--- a/compendium/modules/w07-sequences-exercise.tex
+++ b/compendium/modules/w07-sequences-exercise.tex
@@ -239,15 +239,7 @@ Använd denna algoritm:
 \code|  new Mutant).apply(0).int| & \code|0 | eftersom den ej djupkopierade kopian av typen \code|ArrayBuffer| refererar samma instans på första platsen som både \code|ys| och \code|xs| och \code|x(0).int| blev noll i en tilldelning på rad 5 i REPL-körningen\\ \hline
 \end{tabular}
 
-\vspace{0.5em}\noindent Observera alltså att kopiering med \code{toArray}, \code{toVector}, \code{toBuffer}, etc. \emph{inte är djup}, d.v.s det är bara elementreferenserna som delas i en samling av ny typ.
-Om du gör \code{toXXX} på en samling som redan är av typen \code{XXX} sker ingenting annat än att samlingsreferensen returneras -- det är bara vid omvandling till en \emph{ny} typ av samling som kopiering av \emph{referenserna} sker,  fortfarande utan någon djupkopiering (alltså ingen instansiering av nya element med kopierat innehåll).
-\begin{REPL}
-scala> val a = Array(5)
-a: Array[Int] = Array(5)
-
-scala> a.toArray eq a
-res0: Boolean = true
-\end{REPL}
+\vspace{0.5em}\noindent Observera alltså att kopiering med \code{toArray}, \code{toVector}, \code{toBuffer}, etc. \emph{inte är djup}, d.v.s. det är bara instansreferenserna som kopieras och inte själva instanserna.
 
 
 \SubtaskSolved


### PR DESCRIPTION
In Scala 2.13, calling toArray on an Array does create a new Array.

There are still cases in Scala 2.13 where calling toXXX doesn't create a new collection, but as far as I know this only happens with immutable collections, so the fact that there are cases where no new collection gets created is mostly irrelevant.