### PR TITLE
Fix workspace link in shuffle instructions

### DIFF
--- a/compendium/modules/w07-sequences-lab-goals.tex
+++ b/compendium/modules/w07-sequences-lab-goals.tex
@@ -1,5 +1,5 @@
 %!TEX encoding = UTF-8 Unicode
-%!TEX root = ../compendium2.tex
+%!TEX root = ../compendium1.tex
 
 \item Kunna skapa och använda sekvenssamlingar.
 \item Kunna implementera sekvensalgoritmen SHUFFLE som modifierar innehållet i en array på plats.

--- a/compendium/modules/w07-sequences-lab.tex
+++ b/compendium/modules/w07-sequences-lab.tex
@@ -1,6 +1,6 @@
 %!TEX encoding = UTF-8 Unicode
 
-%!TEX root = ../compendium2.tex
+%!TEX root = ../compendium1.tex
 
 \Lab{\LabWeekSEVEN}
 
@@ -62,7 +62,7 @@ Med hjälp av klasserna \code{TestHand} och \code{TestDeck} kan du testa så att
 När dina implementationer av metoderna \code{full} och \code{shuffle} fungerar ska du använda \code{Deck} i singelobjektet \code{PokerProbability} för att ta reda på sannolikheter för att olika pokerhänder uppkommer när man delar ut 5 kort ur en bra blandad kortlek.
 
 Till din hjälp har du nedan kodfiler, där några har ofärdig kod som du ska färdigställa. All kod  ligger i ett paket med namnet \code{cards}.\footnote{Du kan bläddra bland klasserna i paketet cards här: \\
-\href{https://github.com/lunduniversity/introprog/tree/master/workspace/w07_shuffle/src/main/scala/cards}{\mbox{\fontsize{9}{11}\selectfont  https://github.com/lunduniversity/introprog/tree/master/workspace/w06\_shuffle/src/main/scala/cards}}}
+\href{https://github.com/lunduniversity/introprog/tree/master/workspace/w07_shuffle/src/main/scala/cards}{\mbox{\fontsize{9}{11}\selectfont  https://github.com/lunduniversity/introprog/tree/master/workspace/w07\_shuffle/src/main/scala/cards}}}
 
 \begin{itemize}
 \item \code{Card.scala} i fig. \ref{shuffle:fig-card} innehåller den färdigimplementerade case-klassen \code{Card} som representerar ett kort och har en koncis \code{toString} med valör och svit (färg).


### PR DESCRIPTION
Seems like the actual link got fixed earlier before but not the text...