### PR TITLE
Use real name instead of username in version control example

### DIFF
--- a/compendium/postchapters/version-control.tex
+++ b/compendium/postchapters/version-control.tex
@@ -73,16 +73,15 @@ Det finns även många andra grafiska användargränssnitt till git, t.ex. \href
 
 \subsection{Anpassa Git}
 
-Innan du börjar använda git, konfigurera ditt användarnamn och din email med nedan terminalkommando, där du anger ditt användarnamn i stället för \code{fornamnefternamn} och din mejladress i stället för \code{mejladr@plats.se}:
+Innan du börjar använda git, konfigurera ditt namn och din email med nedan terminalkommando, där du anger ditt namn i stället för \code{Förnamn Efternamn} och din mejladress i stället för \code{mejladr@plats.se}. Namnet och mejladressen kommer lagras i varje commit som du gör så att det går att se vem som har gjort en given ändring.
 \begin{REPLnonum}
-> git config --global user.name fornamnefternamn
+> git config --global user.name "Förnamn Efternamn"
 > git config --global user.email mejladr@plats.se
 \end{REPLnonum}
-Det är bra att välja \textit{ett} användarnamn, för \textit{alla} repo, även kodlagringsplatser på nätet; förslagsvis \code{fornamnefternamn} utan svenska tecken,  så att du blir lätt att känna igen, speciellt om du jobbar med öppen källkod där ditt namn kommer associeras med alla de kodbidrag du gör under ditt yrkesliv.
 
 Läs mer om hur du gör andra inställningar här, t.ex. hur du anger vilken editor som git startar när du ska skriva commit-beskrivningar: \\ \url{https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup}
-  
-  
+
+
 \subsection{Använda git}
 
 Nedan listas några vanliga terminalkommandon i Git.
@@ -168,7 +167,9 @@ Nedan beskrivs några vanliga nätplatser för öppen och sluten kodlagring, som
 
 \subsubsection{Använda kodlagringsplatser}
 
-Om du inte redan gjort det är det bra om du registrerar ditt användarnamn, förslagsvis \code{fornamnefternamn} som ett ord utan svenska tecken med små bokstäver, på någon eller alla av ovan sajter, dels för att paxa ditt namn och dels för börja samarbeta med utvecklare världen över. Om du inte vet vilken du ska välja, börja med \url{https://github.com}. Om du vill att även kodlagringssajten ska drivas av öppen källkod, testa \url{https://gitlab.com}. 
+Om du inte redan gjort det är det bra om du registrerar ditt användarnamn, förslagsvis \code{fornamnefternamn} som ett ord utan svenska tecken med små bokstäver, på någon eller alla av ovan sajter, dels för att paxa ditt namn och dels för börja samarbeta med utvecklare världen över. Det är bra att välja \textit{ett} användarnamn för \textit{alla} kodlagringsplatser på nätet, speciellt om du jobbar med öppen källkod där ditt namn kommer associeras med alla de kodbidrag du gör under ditt yrkesliv.
+
+Om du inte vet vilken sajt du ska välja, börja med \url{https://github.com}. Om du vill att även kodlagringssajten ska drivas av öppen källkod, testa \url{https://gitlab.com}.
 
 Med en Git-baserad kodlagringsplats får du möjlighet att synka ditt lokala repo mot en server på nätet med hjälp av \code{git}-kommandon i terminalen eller via en Git-klient med grafiskt användargränssnitt, se avsnitt \ref{subsection:install-git}. 
 


### PR DESCRIPTION
In my experience, most people who do not wish to be pseudonymous set git's `user.name` setting to their real name with spaces and diacritics. There is no technical obstacle to doing so, there is no expectation that the name is character-by-character identical to whatever online username you are using, and it looks nicer.