### PR TITLE
Fix #502 removed deprecated use of prepend in Chapters 7.2.3 and L.7.3

### DIFF
--- a/compendium/modules/w07-sequences-exercise.tex
+++ b/compendium/modules/w07-sequences-exercise.tex
@@ -1106,7 +1106,7 @@ def insertDropLast(xs: Array[Int], x: Int, pos: Int): Unit = {
 \Task  \what~ Samlingen \code{ListBuffer} är en förändringsbar sekvens som är snabb och minnessnål vid tillägg i början \Eng{prepend}. Undersök vad som händer här:
 \begin{REPL}
 scala> val xs = scala.collection.mutable.ListBuffer.empty[Int]
-scala> xs.prepend(1, 1)
+scala> xs.prependAll(Vector(1, 1))
 scala> while (xs.head < 100) {xs.prepend(xs.take(2).sum); println(xs)}
 scala> xs.reverse.toList
 \end{REPL}
@@ -1137,7 +1137,7 @@ Hur lång ska en Fibonacci-sekvens vara för att det sista elementet ska vara s�
 \begin{Code}
 def fib(max: Long): List[Long] = {
   val xs = scala.collection.mutable.ListBuffer.empty[Long]
-  xs.prepend(1, 1)
+  xs.prependAll(Vector(1, 1))
   while (xs.head < max) xs.prepend(xs.take(2).sum)
   xs.reverse.drop(1).toList
 }
@@ -1156,7 +1156,7 @@ res0: Int = 46
 \begin{Code}
 def fibBig(max: BigInt): List[BigInt] = {
   val xs = scala.collection.mutable.ListBuffer.empty[BigInt]
-  xs.prepend(1, 1)
+  xs.prependAll(Vector(1, 1))
   while (xs.head < max) xs.prepend(xs.take(2).sum)
   xs.reverse.drop(1).toList
 }

--- a/compendium/modules/w07-sequences-exercise.tex
+++ b/compendium/modules/w07-sequences-exercise.tex
@@ -1156,7 +1156,7 @@ res0: Int = 46
 \begin{Code}
 def fibBig(max: BigInt): List[BigInt] = {
   val xs = scala.collection.mutable.ListBuffer.empty[BigInt]
-  xs.prependAll(Vector(1, 1))
+  xs.prependAll(Vector(BigInt(1), BigInt(1))
   while (xs.head < max) xs.prepend(xs.take(2).sum)
   xs.reverse.drop(1).toList
 }


### PR DESCRIPTION
Fixes issue #502 and removes the deprecated uses of prepend and swaps it with prependAll.