### PR TITLE
w05: Fix exercise quizzes and improve solutions

### DIFF
--- a/compendium/modules/w05-classes-exercise.tex
+++ b/compendium/modules/w05-classes-exercise.tex
@@ -89,7 +89,7 @@ class  Punkt       { var x = 3; var y = 2 }
 ~\\ \emph{fel} & \emph{typ} & \emph{förklaring} \\\hline
 
 \code|value is not a member of object|
-& kompileringsfel & det finns ingen instans med namnet \code|Punkt|. (Det lite udda felmeddelandet syftar på att det i klassens autogenererade konstruktionsombud saknas en variabel med namnet \code|x|.)\\ % Footnote verkar inte funka, så förklaringen får tyvärr stå i själva tabellen.
+& kompileringsfel & det finns ingen instans med namnet \code|Punkt|. \newline \emph{Felmeddelandet syftar på att det i klassens autogenererade konstruktor-ombud saknas en variabel med namnet} \code|x|.\\ % Footnote verkar inte funka, så förklaringen får tyvärr stå i själva tabellen.
 
 \verb|Not found: type|
 & kompileringsfel & det finns ingen klass som heter \code|Singelpunkt|\\
@@ -217,7 +217,7 @@ Antag att uttrycken till vänster evalueras uppifrån och ned. Vilket REPL-svar 
 
 \Subtask Vilken returtyp kommer kompilatorn härleda för funktionen \code{MutablePt.move}?
 
-\Subtask Vad är skillnaden mellan instansiering med automatiska apply-metoder och instansiering med \code|new|? Finns det något fall där \code|new| måste användas?
+\Subtask Vad är skillnaden mellan instansiering med universella apply-metoder och instansiering med \code|new|? Finns det något fall där \code|new| måste användas?
 
 \Subtask Vad kallas sådana metoder som \code{ def x } och \code{ def y } ovan?
 
@@ -239,7 +239,7 @@ MutablePt
 \end{REPL}
 
 \SubtaskSolved
-Instansiering med automatiska apply-metoder är godis som gör koden enklare att läsa och skriva. Detta är möjligt tack vare att det under huven vid kompilering skapas ett konstruktorombud \Eng{constructor proxy} vilket är ett kompanjonsobjekt med tillhörande apply-metod, som instansierar objektet med nyckelordet \code|new|.
+Instansiering med universella apply-metoder \Eng{universal apply methods} är godis som gör koden enklare att läsa och skriva. Detta är möjligt tack vare att det vid kompilering automatiskt skapas ett konstruktor-ombud \Eng{constructor proxy} som instansierar objektet med nyckelordet \code|new|. Ett konstruktor-ombud är ett kompanjonsobjekt med tillhörande apply-metod.
 
 Ett fall då \code|new| uttryckligen måste användas är vid implementering av egen apply-metod i ett kompanjonsobjekt. Om \code|new| inte används inuti apply-metoden, kommer samma metod att anropas rekursivt istället för att en ny instans skapas. Se följande exempel:
 
@@ -252,12 +252,12 @@ object Point3D:
     if secretNumber == 42 then
       Point3D(x, y, z) // Koden kommer fastna i en evig loop.
 
-    else new Point3D(x, y, z) // Funkar eftersom new används.
+    else new Point3D(x, y, z) // Funkar eftersom 'new' används.
 \end{Code}
 
 
 
-\SubtaskSolved En metoder som avläser (delar av) ett objekts (privata) tillstånd utan att ändra det kallas en \emph{getter}.
+\SubtaskSolved En metod som avläser (delar av) ett objekts (privata) tillstånd utan att ändra det kallas för en \emph{getter}.
 
 \QUESTEND
 
@@ -304,11 +304,11 @@ scala> Gurka(50) == Bil("Sedan")
 val res0: Boolean = false
 \end{REPL}
 
-\SubtaskSolved Likhetsjämförelser mellan primitiva typer typkollas av kompilatorn och kan därför ge kompileringsfel om två olika typer, som inte kan jämföras, jämförs. Detta gäller dock inte egendefinierade typer, vilket innebär att en likhetsjämförelse mellan olika egendefinierade typer alltid resulterar i \code|false|.
+\SubtaskSolved Likhetsjämförelser mellan primitiva typer typkollas av kompilatorn och kan därför ge kompileringsfel om två olika typer, som inte kan jämföras, jämförs med varandra. Detta gäller dock inte egendefinierade typer, vilket innebär att en likhetsjämförelse mellan olika egendefinierade typer alltid resulterar i \code|false|.
 
 Ett kompileringsfel som i fallet med de primitiva typerna är att föredra då det förbättrar typsäkerheten, vilket minskar risken för oupptäckta buggar.
 
-\SubtaskSolved Det går att få samma typkoll för egendefinierade typer som för primitiva typer genom en importering av \code|scala.language.strictEquality|.
+\SubtaskSolved Det går att få samma typkoll för egendefinierade typer som för primitiva typer genom att importera \code|scala.language.strictEquality|.
 
 \begin{Code}
 import scala.language.strictEquality

--- a/compendium/modules/w05-classes-exercise.tex
+++ b/compendium/modules/w05-classes-exercise.tex
@@ -262,71 +262,6 @@ object Point3D:
 \QUESTEND
 
 
-\WHAT{Innehållslikhet mellan olika typer.}
-
-\QUESTBEGIN
-
-\Task \what~Klistra in nedan klasser i REPL och undersök vad som händer.
-
-\begin{Code}
-class Gurka(val vikt: Int)
-
-class Bil(val typ: String)
-\end{Code}
-
-\begin{REPL}
-scala> class Gurka(val vikt: Int)
-     |
-     | class Bil(val typ: String)
-// defined class Gurka
-// defined class Bil
-
-scala> 42 == "Fyrtiotvå"
-
-scala> Gurka(50) == Bil("Sedan")
-
-\end{REPL}
-
-\Subtask Varför skiljer sig uttryckens resultat med varandra? Vilket resultat är att föredra?
-
-\Subtask Hur kan man ändra i koden för att få det föredragna resultatet?
-
-\SOLUTION
-
-\TaskSolved \what~
-\begin{REPL}
-scala> 42 == "Fyrtiotvå"
-1 |42 == "Fyrtiotvå"
-  |^^^^^^^^^^^^^^^^^
-  |Values of types Int and String cannot be compared with == or !=
-
-scala> Gurka(50) == Bil("Sedan")
-val res0: Boolean = false
-\end{REPL}
-
-\SubtaskSolved Likhetsjämförelser mellan primitiva typer typkollas av kompilatorn och kan därför ge kompileringsfel om två olika typer, som inte kan jämföras, jämförs med varandra. Detta gäller dock inte egendefinierade typer, vilket innebär att en likhetsjämförelse mellan olika egendefinierade typer alltid resulterar i \code|false|.
-
-Ett kompileringsfel som i fallet med de primitiva typerna är att föredra då det förbättrar typsäkerheten, vilket minskar risken för oupptäckta buggar.
-
-\SubtaskSolved Det går att få samma typkoll för egendefinierade typer som för primitiva typer genom att importera \code|scala.language.strictEquality|.
-
-\begin{Code}
-import scala.language.strictEquality
-class Gurka(val vikt: Int)
-
-class Bil(val typ: String)
-\end{Code}
-
-\begin{REPL}
-scala> Gurka(50) == Bil("Sedan")
-1 |Gurka(50) == Bil("Sedan")
-  |^^^^^^^^^^^^^^^^^^^^^^^^^
-  |Values of types Gurka and Bil cannot be compared with == or !=
-\end{REPL}
-
-\QUESTEND
-
-
 \WHAT{Oföränderlig Java-klass.}
 
 \QUESTBEGIN
@@ -900,6 +835,69 @@ val res1: Int = 3
 \clearpage
 
 \AdvancedTasks %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\WHAT{Innehållslikhet mellan olika typer.}
+
+\QUESTBEGIN
+
+\Task \what~Klistra in nedan klasser i REPL och undersök vad som händer.
+
+\begin{Code}
+class Gurka(val vikt: Int)
+
+class Bil(val typ: String)
+\end{Code}
+
+\begin{REPL}
+scala> class Gurka(val vikt: Int)
+     |
+     | class Bil(val typ: String)
+// defined class Gurka
+// defined class Bil
+
+scala> 42 == "Fyrtiotvå"
+
+scala> Gurka(50) == Bil("Sedan")
+
+\end{REPL}
+
+Finns det något resultat som är problematiskt, och i så fall, varför?
+
+
+\SOLUTION
+
+\TaskSolved \what~
+\begin{REPL}
+scala> 42 == "Fyrtiotvå"
+1 |42 == "Fyrtiotvå"
+  |^^^^^^^^^^^^^^^^^
+  |Values of types Int and String cannot be compared with == or !=
+
+scala> Gurka(50) == Bil("Sedan")
+val res0: Boolean = false
+\end{REPL}
+
+Det andra uttrycket är problematiskt eftersom det alltid kommer resultera i \code|false|, då klasserna \code|Gurka| och \code|Bil| är två ojämförbara typer som inte bör jämföras med avseende på innehållslikhet. Detta försämrar typsäkerheten vilket ökar risken för svårupptäckta buggar där fel typer jämförs.
+
+Likhetsjämförelser som sker mellan primitiva typer typkollas av kompilatorn och kan därför ge kompileringsfel om två olika typer, såsom \code|Int| och \code|String|, jämförs med varandra. Detta gäller dock i regel inte egendefinierade typer, vilket alltså innebär att en likhetsjämförelse mellan olika egendefinierade typer alltid resulterar i \code|false|.
+
+Det är emellertid möjligt att få samma typkoll för egendefinierade typer som för primitiva typer genom att importera \code|scala.language.strictEquality|.
+
+\begin{Code}
+import scala.language.strictEquality
+class Gurka(val vikt: Int)
+
+class Bil(val typ: String)
+\end{Code}
+
+\begin{REPL}
+scala> Gurka(50) == Bil("Sedan")
+1 |Gurka(50) == Bil("Sedan")
+  |^^^^^^^^^^^^^^^^^^^^^^^^^
+  |Values of types Gurka and Bil cannot be compared with == or !=
+\end{REPL}
+
+\QUESTEND
 
 
 \WHAT{Attributrepresentation. Privat konstruktor. Fabriksmetod.}

--- a/compendium/modules/w05-classes-exercise.tex
+++ b/compendium/modules/w05-classes-exercise.tex
@@ -371,11 +371,11 @@ val res0: Int = 1
 
 \Task\label{exe:classes:labprep}  \what~I nästa laboration ska du bygga vidare på \code{blockmole}-labben och göra ett spel för två spelare där varje spelare styr sin \emph{egen} instans av en \code{blockmole}. Vi måste då göra om \code{Mole} så att den blir en klass i stället för ett singelobjekt. Gör färdigt klasserna nedan och testa noggrant så att de fungerar. 
 
-Alla klasser ska tillhöra \code{package blockbattle} och ligga i varsin egen fil med samma namn som klassen, t.ex. \code{Pos.scala}. När du har mer än en kodfil som du vill kompilera om upprepade gånger vid stegvis implementation och felsökning, underlättas ditt arbetet stort om du använder byggverktyget \code{sbt} som finns installerat på skolans datorer (se även Appendix~\ref{appendix:build}). Lägg en fil med namnet \code{build.sbt} i biblioteket där du jobbar t.ex. \code{~/pgk/w06/lab} med detta innehåll:
+Alla klasser ska tillhöra \code{package blockbattle} och ligga i varsin egen fil med samma namn som klassen, t.ex. \code{Pos.scala}. När du har mer än en kodfil som du vill kompilera om upprepade gånger vid stegvis implementation och felsökning, underlättas ditt arbetet stort om du använder byggverktyget \code{sbt} som finns installerat på skolans datorer (se även Appendix~\ref{appendix:build}). Lägg en fil med namnet \code{build.sbt} i katalogen där du jobbar, t.ex. \code{~/pgk/w06/lab}, med detta innehåll:
 \begin{Code}
 scalaVersion := "3.0.0"
 \end{Code}
-Då kan du i ett eget terminalfönster köra igång \code{sbt} och sedan kommandot \code{~compile}. Då kompileras din ändrade kod om automatiskt varje gång du sparar en scala-fil i detta bibliotek.
+Då kan du i ett eget terminalfönster köra igång \code{sbt} och sedan kommandot \code{~compile}. Då kompileras din ändrade kod om automatiskt varje gång du sparar en scala-fil i denna katalog.
 \begin{REPLnonum}
 >sbt
 sbt> ~compile
@@ -477,7 +477,7 @@ val res7: blockbattle.Pos = Pos(0,2)
 
 \Subtask Under laborationen behöver du en klass \code{blockbattle.BlockWindow} som med hjälp av \code{introprog.PixelWindow} erbjuder blockgrafik. Varje instans av \code{BlockWindow} ska ha ett attribut som refererar till en \code{PixelWindow}-instans. Detta kallas \textbf{aggregering} \Eng{aggregation}.\footnote{\url{https://en.wikipedia.org/wiki/Object\_composition\#Aggregation}}
 
-För att det ska gå att kompilera och testa din \code{BlockWindow}-klass behöver du ha \code{introprog}-paketet på classpath. Med byggverktyget \code{sbt} hamnar alla jar-filer som ligger i biblioteket \texttt{lib} automatiskt på classpath när du gör \code{compile}, \code{run}, etc.
+För att det ska gå att kompilera och testa din \code{BlockWindow}-klass behöver du ha \code{introprog}-paketet på classpath. Med byggverktyget \code{sbt} hamnar alla jar-filer som ligger i katalogen \texttt{lib} automatiskt på classpath när du gör \code{compile}, \code{run}, etc.
 
 \begin{REPLnonum}
 > mkdir lib

--- a/quiz/QuizData.scala
+++ b/quiz/QuizData.scala
@@ -234,8 +234,8 @@ object QuizData {  // to generate tables for a concept connection quizes in late
 
     QuizID("quiz-w05-class-instance") -> Vector(  //programs
       "\\code|Singelpunkt.x               |" -> "\\code|1|",
-      "\\code|Punkt.x                     |" -> "\\code|error: not found: value|",
-      "\\code|val p  = new Singelpunkt    |" -> "\\verb|error: not found: type|",
+      "\\code|Punkt.x                     |" -> "\\code|value is not a member of object|",
+      "\\code|val p  = new Singelpunkt    |" -> "\\verb|Not found: type|",
       "\\code|val p1 = new Punkt          |" -> "\\verb|p1: Punkt = Punkt@27a1a53c|",
       "\\code|val p2 = new Punkt          |" -> "\\verb|p2: Punkt = Punkt@51ab04bd|",
       "\\code|{ p1.x = 1; p2.x }          |" -> "\\code|3|",
@@ -245,34 +245,32 @@ object QuizData {  // to generate tables for a concept connection quizes in late
     ).filter(_._1.trim.nonEmpty),
 
     QuizID("quiz-w05-class-param") -> Vector(  //programs
-      "\\code|val p1 = Point(1, 2)        |" -> "\\code|error: not found: value|",
-      "\\code|val p2 = new Point          |" -> "\\code|error: not enough arguments|",
-      "\\code|val p1 = new Point(1, 2)    |" -> "\\verb|p1: Point = Point@30ef773e|",
+      "\\code|val p1 = Point(1, 2)        |" -> "\\code|p1: Point = Point@30ef773e|",
+      "\\code|val p2 = new Point          |" -> "\\code|missing argument for parameter|",
       "\\code|val p2 = new Point(3, 4)    |" -> "\\verb|p2: Point = Point@218cf600|",
       "\\code|p2.x - p1.x                 |" -> "\\code|2|",
       "\\code|(new Point(0, 1)).y         |" -> "\\code|1|",
-      "\\code|new Point(0, 1, 2)          |" -> "\\code|error: too many arguments|",
+      "\\code|new Point(0, 1, 2)          |" -> "\\code|too many arguments for constructor|",
       "" -> ""
     ).filter(_._1.trim.nonEmpty),
 
     QuizID("quiz-w05-class-arg") -> Vector(  //programs
       "\\code|val p1 = new Point3D        |" -> "\\verb|p1: Point3D = Point3D@2eb37eee|",
       "\\code|val p2 = new Point3D(y = 1) |" -> "\\verb|p2: Point3D = Point3D@65a9e8d7|",
-      "\\code|(new Point3D(z = 2)).z      |" -> "\\code|error: not found: value|",
-      "\\code|p2.y = 0                    |" -> "\\code|error: reassignment to val|",
+      "\\code|(new Point3D(z = 2)).z      |" -> "\\code|value cannot be accessed|",
+      "\\code|p2.y = 0                    |" -> "\\code|Reassignment to val|",
       "\\code|p2.y == 0                   |" -> "\\code|false|",
       "\\code|p1.x == (new Point3D).x     |" -> "\\code|true|",
       "" -> ""
     ).filter(_._1.trim.nonEmpty),
 
     QuizID("quiz-w05-case-class") -> Vector(  //programs
-      "\\code|val p1 = new Pt(1,2)        |" -> "\\code|Pt(1,2)|",
-      "\\code|val p2 = Pt(y=3)            |" -> "\\code|Pt(0,3)|",
-      "\\code|val p3 = new MutablePt(5, 6)|" -> "\\code|MPt(5,6)|",
-      "\\code|val p4 = Mutable()          |" -> "\\code|error: not found: value|",
-      "\\code|p2.moved(dx=1) == Pt(1, 3)  |" -> "\\code|true|",
-      "\\code|p3.move(dy=1) == new MutablePt(5,7)|" -> "\\code|false|",
-      "\\code|p2 == p3                      |" -> "\\verb|warning: always false|",
+      "\\code|val p1 = new Pt(1, 2)         |" -> "\\code|Pt(1, 2)|",
+      "\\code|val p2 = Pt(y = 3)            |" -> "\\code|Pt(0, 3)|",
+      "\\code|val p3 = new MutablePt(5, 6)  |" -> "\\code|MPt(5, 6)|",
+      "\\code|val p4 = Mutable()            |" -> "\\code|Not found|",
+      "\\code|p2.moved(dx = 1) == Pt(1, 3)  |" -> "\\code|true|",
+      "\\code|p3.move(dy = 1) == new MutablePt(5, 7)|" -> "\\code|false|",
       "" -> ""
     ).filter(_._1.trim.nonEmpty),
 

--- a/quiz/QuizData.scala
+++ b/quiz/QuizData.scala
@@ -245,12 +245,12 @@ object QuizData {  // to generate tables for a concept connection quizes in late
     ).filter(_._1.trim.nonEmpty),
 
     QuizID("quiz-w05-class-param") -> Vector(  //programs
-      "\\code|val p1 = Point(1, 2)        |" -> "\\code|p1: Point = Point@30ef773e|",
-      "\\code|val p2 = Point()            |" -> "\\code|missing argument for parameter|",
+      "\\code|val p1 = Point(1, 2)        |" -> "\\verb|p1: Point = Point@30ef773e|",
+      "\\code|val p2 = Point()            |" -> "\\verb|missing argument for parameter|",
       "\\code|val p2 = Point(3, 4)        |" -> "\\verb|p2: Point = Point@218cf600|",
       "\\code|p2.x - p1.x                 |" -> "\\code|2|",
       "\\code|Point(0, 1).y               |" -> "\\code|1|",
-      "\\code|Point(0, 1, 2)              |" -> "\\code|too many arguments for constructor|",
+      "\\code|Point(0, 1, 2)              |" -> "\\verb|too many arguments for constructor|",
       "" -> ""
     ).filter(_._1.trim.nonEmpty),
 
@@ -265,9 +265,9 @@ object QuizData {  // to generate tables for a concept connection quizes in late
     ).filter(_._1.trim.nonEmpty),
 
     QuizID("quiz-w05-case-class") -> Vector(  //programs
-      "\\code|val p1 = Pt(1, 2)             |" -> "\\code|Pt(1, 2)|",
-      "\\code|val p2 = Pt(y = 3)            |" -> "\\code|Pt(0, 3)|",
-      "\\code|val p3 = MutablePt(5, 6)      |" -> "\\code|MPt(5, 6)|",
+      "\\code|val p1 = Pt(1, 2)             |" -> "\\code|Pt(1,2)|",
+      "\\code|val p2 = Pt(y = 3)            |" -> "\\code|Pt(0,3)|",
+      "\\code|val p3 = MutablePt(5, 6)      |" -> "\\code|MPt(5,6)|",
       "\\code|val p4 = Mutable()            |" -> "\\code|Not found|",
       "\\code|p2.moved(dx = 1) == Pt(1, 3)  |" -> "\\code|true|",
       "\\code|p3.move(dy = 1) == MutablePt(5, 7)|" -> "\\code|false|",

--- a/quiz/QuizData.scala
+++ b/quiz/QuizData.scala
@@ -237,7 +237,7 @@ object QuizData {  // to generate tables for a concept connection quizes in late
       "\\code|Punkt.x                     |" -> "\\code|value is not a member of object|",
       "\\code|val p  = new Singelpunkt    |" -> "\\verb|Not found: type|",
       "\\code|val p1 = new Punkt          |" -> "\\verb|p1: Punkt = Punkt@27a1a53c|",
-      "\\code|val p2 = new Punkt          |" -> "\\verb|p2: Punkt = Punkt@51ab04bd|",
+      "\\code|val p2 = Punkt()            |" -> "\\verb|p2: Punkt = Punkt@51ab04bd|",
       "\\code|{ p1.x = 1; p2.x }          |" -> "\\code|3|",
       "\\code|(new Punkt).y               |" -> "\\code|2|",
       "\\code|{ val p: Punkt = null; p.x }|" -> "\\code|java.lang.NullPointerException|",
@@ -246,31 +246,31 @@ object QuizData {  // to generate tables for a concept connection quizes in late
 
     QuizID("quiz-w05-class-param") -> Vector(  //programs
       "\\code|val p1 = Point(1, 2)        |" -> "\\code|p1: Point = Point@30ef773e|",
-      "\\code|val p2 = new Point          |" -> "\\code|missing argument for parameter|",
-      "\\code|val p2 = new Point(3, 4)    |" -> "\\verb|p2: Point = Point@218cf600|",
+      "\\code|val p2 = Point()            |" -> "\\code|missing argument for parameter|",
+      "\\code|val p2 = Point(3, 4)        |" -> "\\verb|p2: Point = Point@218cf600|",
       "\\code|p2.x - p1.x                 |" -> "\\code|2|",
-      "\\code|(new Point(0, 1)).y         |" -> "\\code|1|",
-      "\\code|new Point(0, 1, 2)          |" -> "\\code|too many arguments for constructor|",
+      "\\code|Point(0, 1).y               |" -> "\\code|1|",
+      "\\code|Point(0, 1, 2)              |" -> "\\code|too many arguments for constructor|",
       "" -> ""
     ).filter(_._1.trim.nonEmpty),
 
     QuizID("quiz-w05-class-arg") -> Vector(  //programs
-      "\\code|val p1 = new Point3D        |" -> "\\verb|p1: Point3D = Point3D@2eb37eee|",
-      "\\code|val p2 = new Point3D(y = 1) |" -> "\\verb|p2: Point3D = Point3D@65a9e8d7|",
-      "\\code|(new Point3D(z = 2)).z      |" -> "\\code|value cannot be accessed|",
+      "\\code|val p1 = Point3D()          |" -> "\\verb|p1: Point3D = Point3D@2eb37eee|",
+      "\\code|val p2 = Point3D(y = 1)     |" -> "\\verb|p2: Point3D = Point3D@65a9e8d7|",
+      "\\code|Point3D(z = 2).z            |" -> "\\code|value cannot be accessed|",
       "\\code|p2.y = 0                    |" -> "\\code|Reassignment to val|",
       "\\code|p2.y == 0                   |" -> "\\code|false|",
-      "\\code|p1.x == (new Point3D).x     |" -> "\\code|true|",
+      "\\code|p1.x == Point3D().x         |" -> "\\code|true|",
       "" -> ""
     ).filter(_._1.trim.nonEmpty),
 
     QuizID("quiz-w05-case-class") -> Vector(  //programs
-      "\\code|val p1 = new Pt(1, 2)         |" -> "\\code|Pt(1, 2)|",
+      "\\code|val p1 = Pt(1, 2)             |" -> "\\code|Pt(1, 2)|",
       "\\code|val p2 = Pt(y = 3)            |" -> "\\code|Pt(0, 3)|",
-      "\\code|val p3 = new MutablePt(5, 6)  |" -> "\\code|MPt(5, 6)|",
+      "\\code|val p3 = MutablePt(5, 6)      |" -> "\\code|MPt(5, 6)|",
       "\\code|val p4 = Mutable()            |" -> "\\code|Not found|",
       "\\code|p2.moved(dx = 1) == Pt(1, 3)  |" -> "\\code|true|",
-      "\\code|p3.move(dy = 1) == new MutablePt(5, 7)|" -> "\\code|false|",
+      "\\code|p3.move(dy = 1) == MutablePt(5, 7)|" -> "\\code|false|",
       "" -> ""
     ).filter(_._1.trim.nonEmpty),
 


### PR DESCRIPTION
I just discovered that the quizzes in exercise w05 were reset to the version pre-migration, which was due to me incorrectly editing the generated `.tex` files in `compendium/generated` instead of `quiz/QuizData.scala`. This should be fixed in this PR, but I can't build the project as I currently have issues with Scala and sbt, so I haven't been able to check it myself. But according to the Github Actions run it should be fine. I also tried running `sbt build` on another PC that is running Windows, but the build failed there due to Windows missing the program `tail`.