### PR TITLE
quickref: Fix typos

### DIFF
--- a/quickref/quickref.tex
+++ b/quickref/quickref.tex
@@ -300,7 +300,7 @@ Type
 \begin{tabular}{@{}p{\FirstColWidth} l @{}l}\MoveUp
 Import
 & \code|import path.to.name | & \Comment{Makes name directly visible. Can be renamed using \textbf{as}}\\
-& \code|import path.to.* |   & \Comment{Whildcard \code{*} imports all.}\\
+& \code|import path.to.* |   & \Comment{Wildcard \code{*} imports all.}\\
 & \code|import path.to.{a, b as x, c as _} | & \Comment{Import several names, b renamed to x, c not imported.}\\
 \end{tabular}
 }% end small
@@ -333,7 +333,7 @@ Import
 \code|end A| & \Comment{optional end marker checked by compiler, also allowed: \texttt{end class}} \\
 \code|object A: | & \Comment{becomes a \textbf{companion object} if same name and in same code file} \\
 \code|  def apply(i: Int = 0) = |  & \Comment{apply is optional: A.apply(1), A(1), A()} \\
-\code|    new A(i) |  & \Comment{new is needed here to avoid reucrsive call} \\
+\code|    new A(i) |  & \Comment{new is needed here to avoid recursive calls} \\
 \code|  val y = A(1)._x | & \Comment{private members can be accessed in companion} \\
 \end{tabular}
 
@@ -418,7 +418,7 @@ Non-referable reference & \code|null|  &  \multicolumn{3}{l}{\hspace{-0.7em}\Com
 \multicolumn{5}{l}{\hspace{-0.7em}Uninitialized ~~\Comment{mutable AnyRef field set to null}~~~\code|var x: String = scala.compiletime.uninitialized|} \\
 Assignment operator & \code|x += 1|  &  \multicolumn{3}{l}{\hspace{-0.7em}\Comment{expands to~~\code|x = x + 1|~~if no method += is available, works for all operators}} \\
 \vspace{-0.4em}\\
-Empty tuple, unit value& \code|()|  &  \Comment{the only value of type Unit}  & \multicolumn{2}{l}{\textbf{Integer division and reminder:}} \\
+Empty tuple, unit value& \code|()|  &  \Comment{the only value of type Unit}  & \multicolumn{2}{l}{\textbf{Integer division and remainder:}} \\
 2-tuple value   & \code|(1, "hello")| &  \Comment{same as Tuple2(1, "hello")} & \multicolumn{2}{l}{\code|a / b|  \Comment{~no decimals if a, b Int, Short, Byte }}   \\ \vspace{0.5em}
 2-tuple type    & \code|(Int, String)| & \Comment{same as Tuple2[Int, String]} & \multicolumn{2}{l}{\code|a \% b|  \Comment{~fulfills: (a / b) * b + (a \% b) == a}} \\
 \multicolumn{5}{l}{\hspace{-0.7em}Tuple prepend~~~\code|3 *: (1.0, '!')| ~\Comment{of type \texttt{Int\,*:\,Double\,*:\,Char\,*:\,EmptyTuple}~~same as (Int, Double, Char)}}\\

--- a/quickref/quickref.tex
+++ b/quickref/quickref.tex
@@ -333,7 +333,7 @@ Import
 \code|end A| & \Comment{optional end marker checked by compiler, also allowed: \texttt{end class}} \\
 \code|object A: | & \Comment{becomes a \textbf{companion object} if same name and in same code file} \\
 \code|  def apply(i: Int = 0) = |  & \Comment{apply is optional: A.apply(1), A(1), A()} \\
-\code|    new A(i) |  & \Comment{new is needed here to avoid recursive calls} \\
+\code|    new A(i) |  & \Comment{new is needed here to avoid recursive call} \\
 \code|  val y = A(1)._x | & \Comment{private members can be accessed in companion} \\
 \end{tabular}
 


### PR DESCRIPTION
Fixed some typos that I found in quickref. Also changed `call` to be in plural (`recursive call` -> `recursive calls`).