### PR TITLE
updating example code for clarity

### DIFF
--- a/slides/body/lect-w02-codestruct.tex
+++ b/slides/body/lect-w02-codestruct.tex
@@ -697,7 +697,7 @@ Om flera parametrar använd kommatecken. Om flera satser använd indentering (oc
 \begin{Code}[basicstyle=\ttfamily\fontsize{8}{10}\selectfont]
 def isHighscore(points: Int, high: Int): Boolean = {
   val highscore: Boolean = points > high
-  if highscore then println(":)") else print(":(")
+  if highscore then println(":)") else println(":(")
   highscore
 }
 \end{Code}


### PR DESCRIPTION
Changing from a print to println to avoid collision status text in sbt since it prints directly on the line. This is also concurrent with function usage in other parts of the code.