### PR TITLE
Removing duplicate chapters, an update on #593

### DIFF
--- a/slides/body/lect-w03-functions.tex
+++ b/slides/body/lect-w03-functions.tex
@@ -413,7 +413,6 @@ val res1: Int = 40
 \end{REPL}
 \end{Slide}
 
-
 \begin{Slide}{Applicera funktioner på element i samlingar med \texttt{map}}\SlideFontSmall
 \begin{Code}
 def öka(x: Int) = x + 1
@@ -422,15 +421,16 @@ def minska(x: Int) = x - 1
 
 val xs = Vector(1, 2, 3)
 \end{Code}
+\pause
 Metoden \Emph{\texttt{map}} fungerar på alla Scala-samlingar och tar \Emph{en funktion som argument} och applicerar denna funktion på alla element och \Alert{skapar en ny samling} med resultaten:
 \begin{REPL}
 scala> xs.map(öka)
-val res0: scala.collection.immutable.Vector[Int] = Vector(2, 3, 4)
+val res0: ???   // vad blir resultatet?
 
 scala> xs.map(minska)
-val res1: scala.collection.immutable.Vector[Int] = Vector(0, 1, 2)
+val res1: ???   // vad blir resultatet?
 \end{REPL}
-En funktion som har funktionsvärden som indata kallas en\\ \Emph{högre ordningens funktion}  \Eng{higher-order function}.
+En funktion som har funktionsvärden som indata (eller utdata) kallas en\\ \Emph{högre ordningens funktion}  \Eng{higher-order function}.
 \end{Slide}
 
 \Subsection{Äkta funktioner}

--- a/slides/body/lect-w03-functions.tex
+++ b/slides/body/lect-w03-functions.tex
@@ -414,28 +414,6 @@ val res1: Int = 40
 \end{Slide}
 
 
-
-\begin{Slide}{Applicera funktioner på element i samlingar med \texttt{map}}\SlideFontSmall
-\begin{Code}
-def öka(x: Int) = x + 1
-
-def minska(x: Int) = x - 1
-
-val xs = Vector(1, 2, 3)
-\end{Code}
-\pause
-Metoden \Emph{\texttt{map}} fungerar på alla Scala-samlingar och tar \Emph{en funktion som argument} och applicerar denna funktion på alla element och \Alert{skapar en ny samling} med resultaten:
-\begin{REPL}
-scala> xs.map(öka)
-val res0: ???   // vad blir resultatet?
-
-scala> xs.map(minska)
-val res1: ???   // vad blir resultatet?
-\end{REPL}
-En funktion som har funktionsvärden som indata (eller utdata) kallas en\\ \Emph{högre ordningens funktion}  \Eng{higher-order function}.
-\end{Slide}
-
-
 \begin{Slide}{Applicera funktioner på element i samlingar med \texttt{map}}\SlideFontSmall
 \begin{Code}
 def öka(x: Int) = x + 1


### PR DESCRIPTION
In the current release chapter 3.1.15 is an exact copy of 3.1.14. This edit removes the duplicity.