### PR TITLE
Tar bort LaTeX-kod från exempelkod

### DIFF
--- a/compendium/modules/w08-matrices-lab.tex
+++ b/compendium/modules/w08-matrices-lab.tex
@@ -149,7 +149,7 @@ Testa med filen \texttt{glider-gun.txt} som ska ha följande innehåll på de f�
 %   def nbrOfNeighbours(row: Int, col: Int): Int = ???
 %
 %   /** Skapar en ny Life-instans med nästa generation av universum.
-%     * Detta sker genom att applicera funktionen \code{rule} på cellerna.
+%     * Detta sker genom att applicera funktionen rule på cellerna.
 %     */
 %   def evolved(rule: (Int, Int, Life) => Boolean = Life.defaultRule):Life = {
 %     var nextGeneration = Life.empty(cells.dim)


### PR DESCRIPTION
Ändrar _\code{rule}_ till endast _rule_, då jag antar att detta är LaTeX som råkat hamna i Scala-koden