### PR TITLE
w12extra: Remove `:paste` instructions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val myStartupTransition: State => State = { s: State =>
 lazy val commonSettings = Seq(
   organization := "se.lth.cs",
   version := "2021.0.1",
-  scalaVersion := "3.0.1",
+  scalaVersion := "3.1.0",
   scalacOptions ++= Seq("-deprecation", "-feature")
 )
 

--- a/compendium/examples/lth-courses/courses.scala
+++ b/compendium/examples/lth-courses/courses.scala
@@ -1,6 +1,6 @@
 object courses:
   def download(): Vector[Course] =
-    val url = "http://cs.lth.se/pgk/lthkurser"
+    val url = "https://fileadmin.cs.lth.se/pgk/lthkurser201819.txt"
     val lines = scala.io.Source.fromURL(url, "UTF-8").getLines.toVector
     lines.drop(1).map(s => Course.fromLine(s, '\t'))
 

--- a/compendium/modules/w12-extra-exercise.tex
+++ b/compendium/modules/w12-extra-exercise.tex
@@ -220,7 +220,7 @@ log_2(n) = b
 \Subtask Via denna URL kan du ladda ner en tab-separerad lista med alla kurser som ges på LTH under innevarande läsår: \url{http://cs.lth.se/pgk/kurser} \\Vilken data finns i filen? Du kan undersöka detta t.ex. med:
 \begin{REPLnonum}
 scala> import scala.io.Source.fromURL
-scala> val url = "http://cs.lth.se/pgk/lthkurser"
+scala> val url = "https://fileadmin.cs.lth.se/pgk/lthkurser201819.txt"
 scala> val data = fromURL(url,"UTF-8").getLines.mkString("\n")
 \end{REPLnonum}
 

--- a/compendium/modules/w12-extra-exercise.tex
+++ b/compendium/modules/w12-extra-exercise.tex
@@ -224,7 +224,7 @@ scala> val url = "https://fileadmin.cs.lth.se/pgk/lthkurser201819.txt"
 scala> val data = fromURL(url,"UTF-8").getLines.mkString("\n")
 \end{REPLnonum}
 
-\Subtask \label{subtask:download-lthcourses} Klistra in objektet \code{courses} på sidan \pageref{lth-courses} med kommandot \code{:paste} i REPL.\footnote{Du kan ladda ner koden från: \\ \href{https://raw.githubusercontent.com/lunduniversity/introprog/master/compendium/examples/lth-courses/courses.scala}{github.com/lunduniversity/introprog/tree/master/compendium/examples/lth-courses/courses.scala}} Vad gör koden? Hur många kurser innehåller \code{courses.lth}?
+\Subtask \label{subtask:download-lthcourses} Klistra in objektet \code{courses} på sidan \pageref{lth-courses} i REPL.\footnote{Du kan ladda ner koden från: \\ \href{https://raw.githubusercontent.com/lunduniversity/introprog/master/compendium/examples/lth-courses/courses.scala}{github.com/lunduniversity/introprog/tree/master/compendium/examples/lth-courses/courses.scala}} Vad gör koden? Hur många kurser innehåller \code{courses.lth}?
 
 \begin{figure}[h]
   \scalainputlisting[basicstyle=\ttfamily\fontsize{10.9}{14}\selectfont]{examples/lth-courses/courses.scala}


### PR DESCRIPTION
Also bump scala version to `3.1.0`