### PR TITLE
quickref: Change mutable set method description

### DIFF
--- a/quickref/quickref.tex
+++ b/quickref/quickref.tex
@@ -905,7 +905,7 @@ Reverse: & \texttt{xs.reverse} & A new sequence with the elements of xs in rever
 
 \texttt{xs ++= ys~~~xs.addAll(ys)} & Adds all elements in ys to set xs and returns xs itself. \\\cline{1-2}
 
-\texttt{xs.add(x)~~~xs.remove(x)} & Adds/removes x to xs and returns true if x was in xs, else false. \\\cline{1-2}
+\texttt{xs.add(x)~~~xs.remove(x)} & Adds/removes x to xs and returns true if xs was mutated, else false. \\\cline{1-2}
 
 %\texttt{xs retain p~~~xs.clear} & Keeps only elements that satisfy predicate p. Remove all.\\   \cline{1-2}
 \texttt{xs(x) = b ~ xs.update(x, b)} & If b is true, adds x to xs, else removes x. Return type Unit.\\   \cline{1-2}


### PR DESCRIPTION
The descriptions for the mutable set methods add and remove described the wrong behaviour. This PR changes the wording to reflect the real behaviour.