### PR TITLE
Update lect-w01-intro.tex to improve clarity

### DIFF
--- a/slides/body/lect-w01-intro.tex
+++ b/slides/body/lect-w01-intro.tex
@@ -278,7 +278,7 @@ Hello World!
 \pause
 \noindent Scala-applikation med \code{@main} framför valfri funktion anger var programmet ska starta:
 \begin{Code}
-@main def run = println("Hello world!")
+@main def hi = println("Hello world!")
 \end{Code}
 \noindent Spara texten ovan i filen \code{hello.scala}.\\
 Kompilera:
@@ -287,7 +287,7 @@ scalac hello.scala
 \end{REPLnonum}
 \noindent Kör:
 \begin{REPLnonum}
-scala run
+scala hi
 \end{REPLnonum}
 \end{Slide}
 


### PR DESCRIPTION
As "scala-cli" has "run" as a command, a beginner who has used the command "scala-cli run ." previous to reading this might mistakenly believe that "scala" also has the command "run". However, it doesn’t: "run" only refers to the main function in this example. It would therefore be more pedagogical if the main function was called something different (like "hi").