### PR TITLE
fixed example 5.1.35 output

### DIFF
--- a/slides/body/lect-w05-classes.tex
+++ b/slides/body/lect-w05-classes.tex
@@ -957,13 +957,13 @@ Använd alltså defaultargument hellre än hjälpkonstruktor.\\
 scala> class Gurka(val vikt: Int)
 
 scala> var g: Gurka = null        // ingen instans allokerad än
-val g: Gurka = null
+var g: Gurka = null
 
 scala> g.vikt
 java.lang.NullPointerException
 
 scala> g = Gurka(42)          // instansen allokeras
-val g: Gurka = Gurka@1ec7d8b3
+g: Gurka = Gurka@1ec7d8b3
 
 scala> g.vikt
 val res0: Int = 42


### PR DESCRIPTION
I noticed the REPL output for Example 5.1.35 didn't match the actual output of running the code.

![alt text](https://cdn.discordapp.com/attachments/631789673366290452/1023881937632374824/Screenshot_from_2022-09-26_10-46-23.png)