### PR TITLE
Removed an unnecessary comparison

### DIFF
--- a/compendium/modules/w07-sequences-exercise.tex
+++ b/compendium/modules/w07-sequences-exercise.tex
@@ -370,7 +370,7 @@ def insert(xs: Array[Int], elem: Int, pos: Int): Array[Int] =
   var i = 0
   while i < pos && i < xs.length do  { result(i) = xs(i); i += 1}
   if i < result.length then { result(i) = elem; i += 1 }
-  while i < result.length && i > 0 do { result(i) = xs(i - 1); i += 1}
+  while i < result.length do { result(i) = xs(i - 1); i += 1}
   result
 
 \end{Code}

--- a/quickref/quickref.tex
+++ b/quickref/quickref.tex
@@ -808,7 +808,7 @@ Traverse: & \texttt{xs.foreach(f)} & Executes f for every element of xs. Return 
   Indexing & \texttt{xs(i)  ~ xs.apply(i)} & The element of xs at index i.\\   \cline{2-3}
 
    and size: & \texttt{xs.length} & Length of sequence. Same as \texttt{size} in \texttt{Iterable}.\\\cline{2-3}
-   & \texttt{xs.indices} & Returns a \texttt{Range} extending from 0 to xs.length - 1.\\\cline{2-3}
+   & \texttt{xs.indices} & Returns a \texttt{Range} extending from 0 until xs.length.\\\cline{2-3}
    & \texttt{xs.isDefinedAt(i)} & True if i is contained in xs.indices.\\\cline{2-3}
    & \texttt{xs.lengthCompare(n)} & Returns -1 if xs is shorter than n, +1 if it is longer, else 0. \\\cline{1-3}
 

--- a/quickref/quickref.tex
+++ b/quickref/quickref.tex
@@ -808,7 +808,7 @@ Traverse: & \texttt{xs.foreach(f)} & Executes f for every element of xs. Return 
   Indexing & \texttt{xs(i)  ~ xs.apply(i)} & The element of xs at index i.\\   \cline{2-3}
 
    and size: & \texttt{xs.length} & Length of sequence. Same as \texttt{size} in \texttt{Iterable}.\\\cline{2-3}
-   & \texttt{xs.indices} & Returns a \texttt{Range} extending from 0 until xs.length.\\\cline{2-3}
+   & \texttt{xs.indices} & Returns a \texttt{Range} extending from 0 to xs.length - 1.\\\cline{2-3}
    & \texttt{xs.isDefinedAt(i)} & True if i is contained in xs.indices.\\\cline{2-3}
    & \texttt{xs.lengthCompare(n)} & Returns -1 if xs is shorter than n, +1 if it is longer, else 0. \\\cline{1-3}
 


### PR DESCRIPTION
Removed && i > 0 in the solution to assignment 7.2.5d as discussed in the discord-server

Since an arrays length can't be shorter than 0 the minimum value for result.length is 1.
if i < result.length then [...] i += 1 guarantees that i is at least equal to 1, so a comparison to see if it's larger than 0 is unnecessary.

The first commit is related to another issue, but I undid the change I made since that issue hasn't been solved yet.