### PR TITLE
fix 717 English literal used in Swedish sentences

### DIFF
--- a/compendium/modules/w01-intro-exercise-goals.tex
+++ b/compendium/modules/w01-intro-exercise-goals.tex
@@ -2,7 +2,7 @@
 
 \item Förstå vad som händer när satser exekveras och uttryck evalueras.
 \item Förstå sekvens, alternativ och repetition.
-\item Känna till literalerna för enkla värden, deras typer och omfång.
+\item Känna till litteralerna för enkla värden, deras typer och omfång.
 \item Kunna deklarera och använda variabler och tilldelning, samt kunna rita bilder av minnessituationen då variablers värden förändras.
 \item Förstå skillnaden mellan olika numeriska typer, kunna omvandla mellan dessa och vara medveten om noggrannhetsproblem som kan uppstå.
 \item Förstå booleska uttryck och värdena \code{true} och \code{false}, samt kunna förenkla booleska uttryck.

--- a/compendium/modules/w01-intro-exercise.tex
+++ b/compendium/modules/w01-intro-exercise.tex
@@ -895,7 +895,7 @@ scala> println(värdeSaknas)
 scala> println(println("hej"))
 \end{REPL}
 
-\Subtask Vilken typ har literalen \code{()}?
+\Subtask Vilken typ har litteralen \code{()}?
 
 \Subtask Vilken returtyp har \code{println}?
 
@@ -1320,7 +1320,7 @@ scala> lotto2
 
 \QUESTBEGIN
 
-\Task \what~Med ett \code{s} framför en strängliteral får man hjälp av kompilatorn att, på ett typsäkert sätt, infoga variabelvärden i en sträng.
+\Task \what~Med ett \code{s} framför en stränglitteral får man hjälp av kompilatorn att, på ett typsäkert sätt, infoga variabelvärden i en sträng.
 Variablernas namn ska föregås med ett dollartecken , t.ex. \code{s"Hej $namn"}.
 Om man vill evaluera ett uttryck placeras detta inom klammer direkt efter dollartecknet, t.ex.
 \code/s"Dubbla längden: ${namn.size * 2}"/
@@ -1846,7 +1846,7 @@ extension (i: Int)
 % \code{Integer.toBinaryString(Int.MaxValue + 1).size} \\*
 % \code{Integer.toBinaryString((math.pow(2,16) - 1).toInt).size} \\*
 % \code{1 + math.log(Long.MaxValue)/math.log(2)}
-%Se även språkspecifikationen för Scala, kapitlet om heltalsliteraler: \\
+%Se även språkspecifikationen för Scala, kapitlet om heltalslitteraler: \\
 %\url{http://www.scala-lang.org/files/archive/spec/2.11/01-lexical-syntax.html#integer-literals}
 %
 %\Subtask Undersök källkoden för paketobjektet \code{scala.math} här: \\

--- a/slides/body/lect-w01-intro.tex
+++ b/slides/body/lect-w01-intro.tex
@@ -339,7 +339,7 @@ upprepa(1000){
 
 \begin{Slide}{Litteraler}
 \begin{itemize}
-\item En literal representerar ett fixt \Emph{värde} i koden och används för att skapa \Alert{data} som programmet ska bearbeta.
+\item En litteral representerar ett fixt \Emph{värde} i koden och används för att skapa \Alert{data} som programmet ska bearbeta.
 \item Exempel: \\
 \begin{tabular}{l l}
 \code|42| & heltalslitteral\\
@@ -412,7 +412,7 @@ Grundtypen \texttt{String} lagras som en \emph{sekvens} av 16-bitars tecken av t
 \begin{Slide}{Uttryck}
 \begin{itemize}
 \item Ett \Emph{uttryck} består av en eller flera delar som efter \Emph{evaluering} ger ett \Alert{resultat}.
-\item Delar i ett uttryck kan t.ex. vara: \\ literaler (42), operatorer (+), funktioner (sin), ...
+\item Delar i ett uttryck kan t.ex. vara: \\ litteraler (42), operatorer (+), funktioner (sin), ...
 \item Exempel:
 \begin{itemize}
 \item Ett enkelt uttryck: \\ \code{42.0}

--- a/slides/body/lect-w03-functions.tex
+++ b/slides/body/lect-w03-functions.tex
@@ -539,9 +539,9 @@ def rnd(n: Int): Int = (math.random() * n).toInt  // oäkta funktion
 
 \begin{Slide}{Anonyma funktioner}
 \begin{itemize}
-\item  Man behöver inte ge funktioner namn. De kan i stället skapas med hjälp av \Emph{funktionsliteraler}.\footnote{Även kallat ''lambda-värde'' eller bara ''lambda'' efter den s.k. lambdakalkylen. \href{https://en.wikipedia.org/wiki/Anonymous_function}{en.wikipedia.org/wiki/Anonymous\_function}}
+\item  Man behöver inte ge funktioner namn. De kan i stället skapas med hjälp av \Emph{funktionslitteraler}.\footnote{Även kallat ''lambda-värde'' eller bara ''lambda'' efter den s.k. lambdakalkylen. \href{https://en.wikipedia.org/wiki/Anonymous_function}{en.wikipedia.org/wiki/Anonymous\_function}}
 
-\item En funktionsliteral har ...
+\item En funktionslitteral har ...
 \begin{enumerate}
 \item en parameterlista (utan funktionsnamn, utan returtyp),
 \item sedan den reserverade teckenkombinationen \code{=>}
@@ -553,7 +553,7 @@ def rnd(n: Int): Int = (math.random() * n).toInt  // oäkta funktion
 (x: Int, y: Int) => x + y             // vilken typ?
 \end{Code}
 \pause
-\item Om kompilatorn kan gissa typerna från sammanhanget så behöver typerna inte anges i själva  funktionsliteralen:
+\item Om kompilatorn kan gissa typerna från sammanhanget så behöver typerna inte anges i själva  funktionslitteralen:
 \begin{Code}[basicstyle=\ttfamily\SlideFontSize{9}{11}]
 val f: (Int, Int) => Int = (x, y) => x + y
 \end{Code}
@@ -562,7 +562,7 @@ val f: (Int, Int) => Int = (x, y) => x + y
 
 
 \begin{Slide}{Applicera anonyma funktioner på element i samlingar}\SlideFontSmall
-Anonym funktion skapad med funktionsliteral direkt i anropet:
+Anonym funktion skapad med funktionslitteral direkt i anropet:
 \begin{REPL}
 scala> val xs = Vector(1, 2, 3)
 
@@ -586,11 +586,11 @@ res2: scala.collection.immutable.Vector[Int] = Vector(2, 3, 4)
 
 
 \begin{Slide}{Platshållarsyntax för anonyma funktioner}\SlideFontSmall
-Understreck i funktionsliteraler kallas \Emph{platshållare} \Eng{placeholder} och medger ett förkortat skrivsätt \Alert{om} den parameter som understrecket representerar används \Alert{endast en gång}.
+Understreck i funktionslitteraler kallas \Emph{platshållare} \Eng{placeholder} och medger ett förkortat skrivsätt \Alert{om} den parameter som understrecket representerar används \Alert{endast en gång}.
 \begin{Code}[basicstyle=\ttfamily\fontsize{10}{12}\selectfont]
 _ + 1
 \end{Code}
-Ovan expanderas av kompilatorn till följande funktionsliteral \\(där namnet på parametern är godtyckligt):
+Ovan expanderas av kompilatorn till följande funktionslitteral \\(där namnet på parametern är godtyckligt):
 \begin{Code}[basicstyle=\ttfamily\fontsize{10}{12}\selectfont]
 x => x + 1
 \end{Code}

--- a/slides/body/lect-w13-on-demand.tex
+++ b/slides/body/lect-w13-on-demand.tex
@@ -311,7 +311,7 @@ Exempel på saker som du kan lägga in tid för i din julpluggkalender:
 %              & uttryck, aritmetik, slumptal, &    stränginterpolatorerna s, f\\
 %              & strängar, grundtyper, Unit, ()  & Float, Byte, Short \\
 %              & skillnad mellan heltal och flyttal \\
-%              & variabler, for, while, if & \\ %hex-literaler, backticks\\
+%              & variabler, for, while, if & \\ %hex-litteraler, backticks\\
 % \hline
 % Program      & main, args, utdata, println, indata & io.StdIn.readLine\\
 %              & Vector, Array, indexering,  &     \\

--- a/slides/simple/intro.tex
+++ b/slides/simple/intro.tex
@@ -340,7 +340,7 @@
 
 \begin{Slide}{Litteraler}
   \begin{itemize}
-  \item En literal representerar ett fixt \Emph{värde} i koden och används för att skapa \Alert{data} som programmet ska bearbeta.
+  \item En litteral representerar ett fixt \Emph{värde} i koden och används för att skapa \Alert{data} som programmet ska bearbeta.
   \item Exempel: \\
   \begin{tabular}{l l}
   \code|42| & heltalslitteral\\
@@ -414,7 +414,7 @@
   \begin{Slide}{Uttryck}
   \begin{itemize}
   \item Ett \Emph{uttryck} består av en eller flera delar som efter \Emph{evaluering} ger ett \Alert{resultat}.
-  \item Delar i ett uttryck kan t.ex. vara: \\ literaler (42), operatorer (+), funktioner (sin), ...
+  \item Delar i ett uttryck kan t.ex. vara: \\ litteraler (42), operatorer (+), funktioner (sin), ...
   \item Exempel:
   \begin{itemize}
   \item Ett enkelt uttryck: \\ \code{42.0}


### PR DESCRIPTION
`grep "literal" **/*.tex` in root-dir now only shows correct usages.