### PR TITLE
fix typo under appendix b

### DIFF
--- a/compendium/postchapters/terminal.tex
+++ b/compendium/postchapters/terminal.tex
@@ -5,7 +5,7 @@
 
 \section{Vad är ett terminalfönster?}
 
-I ett terminalfönster kan man skriva kommandon som kör program och hanterar filer. När man programmerar använder man ofta terminalkommando för att kompilera och exekvera sina program.  
+I ett terminalfönster kan man skriva kommandon som kör program och hanterar filer. När man programmerar använder man ofta terminalkommandon för att kompilera och exekvera sina program.  
  
 \subsubsection{Terminal i Linux}
 


### PR DESCRIPTION
"Terminalkommando" skulle kunna vara plural ("terminalkommandon") eftersom man oftast använder flera olika terminalkommandon när man programmerar.