### PR TITLE
Korrigering av filnamn av sum.scala till sum.sc

### DIFF
--- a/compendium/modules/w02-programs-exercise.tex
+++ b/compendium/modules/w02-programs-exercise.tex
@@ -97,7 +97,7 @@
 
 \Task  \what~
 
-\Subtask Skapa en fil med namn \texttt{sum.scala} i katalogen \code{hello} som du skapade i föregående uppgift med hjälp av en editor, t.ex. VS \code{code}.
+\Subtask Skapa en fil med namn \texttt{sum.sc} i katalogen \code{hello} som du skapade i föregående uppgift med hjälp av en editor, t.ex. VS \code{code}.
 \begin{REPLnonum}
 > cd hello
 > code sum.sc


### PR DESCRIPTION
Det står motsägande filnamn för sum.sc/sum.scala i W02 övningarna. I instruktionen står det att man bör skapa en fil vid namn "sum.scala" men i exemplet står `code sum.sc`.

Mitt commit redigerar instruktionen till att säga "sum.sc" eftersom det står så senare i texten.