### PR TITLE
Punkt tillagd mellan "xs" och "map" i Uppgift 5, W02

### DIFF
--- a/quiz/QuizData.scala
+++ b/quiz/QuizData.scala
@@ -124,7 +124,7 @@ object QuizData {  // to generate tables for a concept connection quizes in late
       "\\code|ys.mkString              |" -> "ny sträng med alla element intill varandra",
       "\\code|ys.mkString(\",\")       |" -> "ny sträng med komma mellan elementen",
       "\\code|xs.map(_.toString)       |" -> "ny samling, elementen omgjorda till strängar",
-      "\\code|xs map (_.toInt)         |" -> "ny samling, elementen omgjorda till heltal",
+      "\\code|xs.map (_.toInt)         |" -> "ny samling, elementen omgjorda till heltal",
       "" -> ""
     ).filter(_._1.trim.nonEmpty),
 

--- a/quiz/QuizData.scala
+++ b/quiz/QuizData.scala
@@ -124,7 +124,7 @@ object QuizData {  // to generate tables for a concept connection quizes in late
       "\\code|ys.mkString              |" -> "ny sträng med alla element intill varandra",
       "\\code|ys.mkString(\",\")       |" -> "ny sträng med komma mellan elementen",
       "\\code|xs.map(_.toString)       |" -> "ny samling, elementen omgjorda till strängar",
-      "\\code|xs.map (_.toInt)         |" -> "ny samling, elementen omgjorda till heltal",
+      "\\code|xs.map(_.toInt)         |" -> "ny samling, elementen omgjorda till heltal",
       "" -> ""
     ).filter(_._1.trim.nonEmpty),
 


### PR DESCRIPTION
Det saknas en punkt mellan `xs` och `main` här: (Uppgift 5, W02)
![image](https://github.com/lunduniversity/introprog/assets/25839246/81c892c0-749e-42cc-8250-8f3188f0b4a4)
Med tanke på svarsalternativ antar jag punkten bör vara där.