### PR TITLE
fix typo in w05 classes & incorrect contribution URL in how to contribute

### DIFF
--- a/compendium/prechapters/how-to-contribute.tex
+++ b/compendium/prechapters/how-to-contribute.tex
@@ -22,7 +22,7 @@ Innan du själv kan implementera ändringar direkt i materialet, behöver du kä
 \item GitHub: \href{https://en.wikipedia.org/wiki/GitHub}{en.wikipedia.org/wiki/GitHub}
 \item sbt: \href{https://en.wikipedia.org/wiki/SBT\_\%28software\%29}{en.wikipedia.org/wiki/SBT\_\%28software\%29}
 \end{itemize}
-Läs mer om hur du bidrar här: \\ \href{https://github.com/lunduniversity/introprog#how-to-contribute-to-this-repo}{github.com/lunduniversity/introprog\#how-to-contribute-to-this-repo}
+Läs mer om hur du bidrar här: \\ \href{https://github.com/lunduniversity/introprog#how-to-contribute}{github.com/lunduniversity/introprog\#how-to-contribute}
 
 
 

--- a/slides/body/lect-w05-classes.tex
+++ b/slides/body/lect-w05-classes.tex
@@ -46,7 +46,7 @@ En klass liknar en \Emph{stämpel}.
 \item En klass är en mall \Eng{template} för att skapa objekt.
 \item Objekt kan skapas med \code{new Klassnamn(parametrar)}, vilket kallas \Emph{instansiering}. 
 \item I Scala 3 är \code{new} valfritt, det räcker med \code{Klassnamn(parametrar)}. 
-\item Ett objekt som skapats med en klassen \code{Klassnamn} som mall kallas för en \Emph{instans} av klassen \code{Klassnamn}.
+\item Ett objekt som skapats med klassen \code{Klassnamn} som mall kallas för en \Emph{instans} av klassen \code{Klassnamn}.
 \item En klass innehåller \Emph{medlemmar} \Eng{members}, som bl.a. kan vara:
   \begin{itemize}
   \item \Emph{attribut}, kallas även fält \Eng{field}: \code{val}, \code{lazy val}, \code{var}


### PR DESCRIPTION
I corrected a simple grammatical error:
_Ett objekt som skapats med en klassen ..._ became **Ett objekt som skapats med klassen**.