### PR TITLE
Fix spelling error in w04 exercise 8

### DIFF
--- a/compendium/modules/w04-objects-exercise.tex
+++ b/compendium/modules/w04-objects-exercise.tex
@@ -568,7 +568,7 @@ I bildminnen i datorer är det vanligt att beskriva färger som en blandning av 
 På veckans labb ska vi använda \code{PixelWindow}, som beskriver RGB-färger med klassen \code{java.awt.Color}.
 Det finns några fördefinierade färger i \code{java.awt.Color}, till exempel \code{java.awt.Color.black} för svart och \code{java.awt.Color.green} för grönt, se vidare dokumentationen för \code{java.awt.Color} i JDK\footnote{\JDKApiUrl}.
 Andra färger kan skapas genom att du själv anger den specifika mängden rött, grönt och blått som behövs för att blanda en viss färg.
-Den tre parametrarna till \code{new java.awt.Color(r, g, b)} anger hur mycket \emph{rött}, \emph{grönt} respektive \emph{blått} som färgen ska innehålla, och mängderna ska vara i intervallet 0--255.
+De tre parametrarna till \code{new java.awt.Color(r, g, b)} anger hur mycket \emph{rött}, \emph{grönt} respektive \emph{blått} som färgen ska innehålla, och mängderna ska vara i intervallet 0--255.
 Färgen $(153, 102, 51)$ innebär ganska mycket rött, lite mindre grönt och ännu mindre blått och det upplevs som brunt.
 
 


### PR DESCRIPTION
In the exercise description of exercise 8 in w04 there is a spelling error. "Den tre parametrarna", should be "De tre parametrarna", because "parametrarna" in this case is plural, and not singular.