### PR TITLE
Remove references to kojo web

### DIFF
--- a/compendium/modules/w01-intro-exercise.tex
+++ b/compendium/modules/w01-intro-exercise.tex
@@ -687,7 +687,7 @@ scala> if monster then println("akta dig!!!")
 
 \Task \what~På veckans laboration ska du använda Kojo för att verifiera att du kan använda sekvens, alternativ, repetition och abstraktion. Med Kojo ska du skapa Scala-program som ritar färgglada figurer med hjälp av ett lättanvänt Scala-bibliotek för \emph{turtle graphics}\footnote{\url{https://en.wikipedia.org/wiki/Turtle_graphics}}. 
 
-Om du använder Kojo som ett grafikbibliotek (rekommenderas) och kör med \texttt{scala-cli} (se Appendix \ref{appendix:kojo}) så kan du använda Scala 3. Men kör du Kojo Desktop eller Webb-Kojo så är det Scala 2 som gäller och även om det mesta i veckans labb fungerar lika i Scala 2 och Scala 3 så kräver Scala 2 den gamla syntaxen för kontrollstrukturer med nödvändiga parenteser runt villkorsuttryck, utan varken \code{do} eller \code{then}, och varken valfria klammerparenteser eller indenteringssyntax. 
+Om du använder Kojo som ett grafikbibliotek (rekommenderas) och kör med \texttt{scala-cli} (se Appendix \ref{appendix:kojo}) så kan du använda Scala 3. Men kör du Kojo Desktop så är det Scala 2 som gäller och även om det mesta i veckans labb fungerar lika i Scala 2 och Scala 3 så kräver Scala 2 den gamla syntaxen för kontrollstrukturer med nödvändiga parenteser runt villkorsuttryck, utan varken \code{do} eller \code{then}, och varken valfria klammerparenteser eller indenteringssyntax. 
 
 Skriv in och kör nedan program med valfri metod enligt Appendix \ref{appendix:kojo}. Notera kopplingen mellan satsernas ordning och vad som händer i ritfönstret.
 
@@ -722,7 +722,7 @@ Försök att underlätta läsbarheten av din kod med hjälp av lämpliga radbryt
 \code|fyll(genomskinlig)| & Gör så att paddan \emph{inte} fyller i något när den ritar. \\
 \code|bredd(20)| & Gör så att pennan får bredden 20. \\
 \code|bakgrund(svart)| & Bakgrundsfärgen blir svart. \\
-%bakgrund2 ger ingen gradient i iKojo på webben http://kojo.lu.se/
+%bakgrund2 ger ingen gradient i Kojo på webben http://kojo.lu.se/
 %\code|bakgrund2(grön,gul)| & Bakgrund med övergång från grönt till gult. \\
 \code|pennaNer|  & Sätter ner paddans penna så att den ritar när den går. \\
 \code|pennaUpp|  & Sänker paddans penna så att den \emph{inte} ritar när den går. \\
@@ -734,7 +734,7 @@ Försök att underlätta läsbarheten av din kod med hjälp av lämpliga radbryt
 \code|gåTill(100, 200)|    & Paddan vrider sig och går till läget (100, 200). \\
 \code|öster|   & Paddan vrider sig så att nosen pekar åt höger. \\
 \code|väster|  & Paddan vrider sig så att nosen pekar åt vänster. \\
-\code|norr|    & Paddan vrider sig så att nosen pekar uppåt. \\
+\code|norr|    & Paddan vrider sig så att nosen pekar uppåt. \\ 
 \code|söder|   & Paddan vrider sig så att nosen pekar neråt. \\
 %mot funkar inte i iKojo på webben http://kojo.lu.se/
 %\code|mot(100,200)|   & Paddan vrider sig så att nosen pekar mot läget (100, 200) \\

--- a/compendium/modules/w01-intro-lab.tex
+++ b/compendium/modules/w01-intro-lab.tex
@@ -10,7 +10,7 @@
 \begin{Preparations}
 \item Repetera veckans föreläsningsmaterial.
 \item \DoExercise{\ExeWeekONE}{01}%Gör övning {\tt \ExeWeekONE} i kapitel \ref{exe:W01}.
-\item Läs om Kojo i appendix \ref{appendix:kojo}. Kojo Desktop är förinstallerat på LTH:s datorer; om du vill installera Kojo Desktop på din egen dator, följ instruktionerna i \ref{appendix:ide:kojo:install}. Du kan också köra Kojo i din webbläsare här: \url{http://kojo.lu.se/}
+\item Läs om Kojo i appendix \ref{appendix:kojo}. Kojo Desktop är förinstallerat på LTH:s datorer; om du vill installera Kojo Desktop på din egen dator, följ instruktionerna i \ref{appendix:ide:kojo:install}.
 \item Läs igenom hela laborationen nedan. Fundera på möjliga lösningar till de uppgifter som är markerade med en penna i marginalen.
 \item Hämta given kod via \href{https://github.com/lunduniversity/introprog/tree/master/workspace/}{kursen github-plats} eller via hemsidan under \href{https://cs.lth.se/pgk/download/}{Download}.
 % \item Ladda hem och studera översiktligt detta dokument (25 sidor, det räcker att du bläddrar igenom dokumentet och får en uppfattning om hur Kojo kan användas): \\ ''Introduction to Kojo'' \url{http://www.kogics.net/kojo-ebooks#intro}

--- a/compendium/postchapters/kojo.tex
+++ b/compendium/postchapters/kojo.tex
@@ -86,12 +86,12 @@ När du startar Kojo första gången, välj ''Svenska'' i språkmenyn och starta
 
 Det finns ett antal användbara kortkommando som du hittar i menyerna i Kojo Desktop. Undersök speciellt Ctrl+Alt+Mellanslag som ger autokomplettering baserat på det du börjat skriva.
 
-\section{Kojo i Webbläsaren}
+%\section{Kojo i Webbläsaren}
 
-En begränsad variant av Kojo finns tillgänglig för programmering direkt i din webbläsare här: \url{http://kojo.lu.se/}
+%En begränsad variant av Kojo finns tillgänglig för programmering direkt i din webbläsare här: \url{http://kojo.lu.se/}
 
-När du trycker på play-knappen så kompileras din kod på en server till Javascript via ScalaJS och därefter körs Javascript-koden i din webbläsare. 
-Kojo på webben är också ännu så länge begränsad till Scala 2 och kräver att du omgärdar sekvenser av rader som hör ihop med \code|{| och \code|}|.
+%När du trycker på play-knappen så kompileras din kod på en server till Javascript via ScalaJS och därefter körs Javascript-koden i din webbläsare. 
+%Kojo på webben är också ännu så länge begränsad till Scala 2 och kräver att du omgärdar sekvenser av rader som hör ihop med \code|{| och \code|}|.
 
 
 \section{Mer om Kojo}

--- a/slides/body/lect-w01-intro.tex
+++ b/slides/body/lect-w01-intro.tex
@@ -1073,11 +1073,11 @@ x: Unit = ()
   \item På övningen kör du Scala REPL för att träna på SARA.
   \item[] \Alert{Läs i Appendix} och på kursens hemsida under ''Verktyg'' om hur du installerar och får igång Scala REPL.
   \item På laborationen använder du barnvänliga \Emph{Kojo} för träna på SARA, med fokus på abstraktion.
-  \item Det finns tre olika sätt att använda Kojo:
+  \item Det finns två olika sätt att använda Kojo:
   \begin{enumerate}
   \item Grafikbiblioteket \textbf{\texttt{kojolib}} i ett fristående Scala program med hjälp av en professionell kodeditor och kompilering och exekvering i terminalen. \Emph{Fungerar fint med nya Scala 3}.
   \item Skrivbordsappen \textbf{Kojo Desktop} med inbyggd barnvänlig editor (endast Scala 2).
-  \item Webbappen \textbf{\url{http://kojo.lu.se/}} som körs direkt i din webbläsare (endast Scala 2, begränsade funktioner).
+  %\item Webbappen \textbf{\url{http://kojo.lu.se/}} som körs direkt i din webbläsare (endast Scala 2, begränsade funktioner).
   \end{enumerate}
 \end{itemize}  
 Alternativ 1 rekommenderas, men om du försenas av tekniskt strul, så kom igång med 2 el. 3 så länge tills du fått hjälp.

--- a/web/tools/tools.html
+++ b/web/tools/tools.html
@@ -139,11 +139,11 @@ Första gången ett projekt öppnas i VS Code så tar det ett tag innan Metals h
 <h3 id="kojo">KOJO</h3>
 <h4 id="windowsmacoslinuxubuntuwsl-installera-kojo">Windows/MacOS/Linux/Ubuntu/WSL: Installera Kojo</h4>
 <p>Vi använder Kojo på första labben. Kojo är utvecklat speciellt för att hjälpa elever i grundskola och gymnasium att lära sig programmera.</p>
-<p>Det finns 3 olika sätt att köra Kojo:</p>
+<p>Det finns 2 olika sätt att köra Kojo:</p>
 <ol class="incremental" style="list-style-type: decimal">
 <li><p>Använd kodbiblioteket <strong>kojolib</strong> (rekommenderas), som fungerar fint med nya Scala 3. Ladda ner filen <a href="https://fileadmin.cs.lth.se/kojolib.scala" class="uri">https://fileadmin.cs.lth.se/kojolib.scala</a> och kör enl. instruktioner i kompendiet, t.ex. med <code>scala-cli repl .</code></p></li>
 <li><p>Kojo Desktop: en nybörjarvänlig utvecklingsmiljö med lättanvänd editor. Använder gamla Scala 2. Följ installationsinstruktioner för ditt system här: <a href="http://www.kogics.net/kojo-download" class="uri">http://www.kogics.net/kojo-download</a></p></li>
-<li><p>Kör Kojo i din webbläsare. Använder gamla Scala 2 och en begränsad uppsättning av de kommandon som finns i Kojo Desktop. Skriv och kör din kod direkt här: <a href="http://kojo.lu.se/" class="uri">http://kojo.lu.se/</a></p></li>
+<!-- <li><p>Kör Kojo i din webbläsare. Använder gamla Scala 2 och en begränsad uppsättning av de kommandon som finns i Kojo Desktop. Skriv och kör din kod direkt här: <a href="http://kojo.lu.se/" class="uri">http://kojo.lu.se/</a></p></li> -->
 </ol>
 <p>Kojo används på <a href="https://www.vattenhallen.lu.se/upplevelser/programmering/">Vattenhallen Science Center</a>. LTH-studenter med programmeringskunskaper och intresse för pedagogik är välkomna att ansöka om att bli programmeringshandledare i Vattenhallen här: <a href="https://www.vattenhallen.lu.se/om-oss/kontakt/vh-student/student-intresseanmalan/" class="uri">https://www.vattenhallen.lu.se/om-oss/kontakt/vh-student/student-intresseanmalan/</a></p>
 <h2 id="hårdvara">Hårdvara</h2>

--- a/web/tools/tools.md
+++ b/web/tools/tools.md
@@ -189,13 +189,14 @@ Läs mer om vad du kan göra med en VS Code och andra verktyg i appendix i [komp
 
 Vi använder Kojo på första labben. Kojo är utvecklat speciellt för att hjälpa elever i grundskola och gymnasium att lära sig programmera. 
 
-Det finns 3 olika sätt att köra Kojo:
+Det finns 2 olika sätt att köra Kojo:
 
 1. Använd kodbiblioteket **kojolib** (rekommenderas), som fungerar fint med nya Scala 3. Ladda ner filen [https://fileadmin.cs.lth.se/kojolib.scala](https://fileadmin.cs.lth.se/kojolib.scala) och kör enl. instruktioner i kompendiet, t.ex. med `scala-cli repl .` 
 
 2. Kojo Desktop: en nybörjarvänlig utvecklingsmiljö med lättanvänd editor. Använder gamla Scala 2. Följ installationsinstruktioner för ditt system här: [http://www.kogics.net/kojo-download](http://www.kogics.net/kojo-download)
 
-3. Kör Kojo i din webbläsare. Använder gamla Scala 2 och en begränsad uppsättning av de kommandon som finns i Kojo Desktop. Skriv och kör din kod direkt här: [http://kojo.lu.se/](http://kojo.lu.se/)
+[//]: # (såhär gör man tydligen kommentarer i markdown?)
+[//]: # (3. Kör Kojo i din webbläsare. Använder gamla Scala 2 och en begränsad uppsättning av de kommandon som finns i Kojo Desktop. Skriv och kör din kod direkt här: [http://kojo.lu.se/](http://kojo.lu.se/))
 
 Kojo används på [Vattenhallen Science Center](https://www.vattenhallen.lu.se/upplevelser/programmering/). LTH-studenter med programmeringskunskaper och intresse för pedagogik är välkomna att ansöka om att bli programmeringshandledare i Vattenhallen här: [https://www.vattenhallen.lu.se/om-oss/kontakt/vh-student/student-intresseanmalan/](https://www.vattenhallen.lu.se/om-oss/kontakt/vh-student/student-intresseanmalan/)
 


### PR DESCRIPTION
Sökte igenom hela report efter `kojo.lu.se` och efter `kojo web`. Detta var referenserna jag hittade. Jag har inte kollat hur printen ser ut.

Behöver review och åsikter om huruvida detta skall göras överhuvudtaget.

fix #745