### PR TITLE
fix lab code skeleton in w04

### DIFF
--- a/compendium/modules/w04-objects-lab.tex
+++ b/compendium/modules/w04-objects-lab.tex
@@ -236,7 +236,7 @@ Lägg till denna funktion i \code{BlockWindow}:
     window.awaitEvent(maxWaitMillis)
     while window.lastEventType != PixelWindow.Event.KeyPressed do
       window.awaitEvent(maxWaitMillis) // skip other events
-    println("KeyPressed: " + window.lastKey)
+    println(s"KeyPressed: ${window.lastKey}")
     window.lastKey
 \end{Code}
 \noindent Det finns olika sorters händelser som ett \code{PixelWindow} kan reagera på, till exempel tangenttryckningar och musklick.

--- a/compendium/modules/w04-objects-lab.tex
+++ b/compendium/modules/w04-objects-lab.tex
@@ -236,7 +236,7 @@ Lägg till denna funktion i \code{BlockWindow}:
     window.awaitEvent(maxWaitMillis)
     while window.lastEventType != PixelWindow.Event.KeyPressed do
       window.awaitEvent(maxWaitMillis) // skip other events
-    println(s"KeyPressed: " + window.lastKey)
+    println("KeyPressed: " + window.lastKey)
     window.lastKey
 \end{Code}
 \noindent Det finns olika sorters händelser som ett \code{PixelWindow} kan reagera på, till exempel tangenttryckningar och musklick.


### PR DESCRIPTION
The "s" is not needed here because string interpolation is not used.