### PR TITLE
Fix solution for exercise w06

### DIFF
--- a/compendium/modules/w06-patterns-exercise.tex
+++ b/compendium/modules/w06-patterns-exercise.tex
@@ -666,7 +666,6 @@ scala> xs.map(_.toOption).flatten.size
 \item Elementet på plats 13 i vektor \code{xs} matchas med något av 2 \code{case}. Om det är en \code{Success} skrivs \textit{:)} ut, om en \code{Failure} skrivs \textit{:(} plus felmeddelandet ut.
 \item -
 \item -
-\item -
 \item Metoden \code{isSuccess} testar om elementet på plats 13 i \code{xs} är en \code{Success} och returnerar \code{true} om så är fallet.
 \item Metoden \code{isFailure} testar om elementet på plats 13 i \code{xs} är en \code{Failure} och returnerar \code{true} om så är fallet.
 \item Metoden \code{count} räknar med hjälp av \code{isFailure} hur många av elementen i \code{xs} som är \code{Failure} och returnerar detta tal.


### PR DESCRIPTION
The solution contains one extra empty row (compare the images below). Therefore, beginning at row 12, the solution and the problem does not match.

![image](https://github.com/lunduniversity/introprog/assets/27621620/abc3b0fc-ea68-4ec1-ab29-f7c9c430351d)
![image](https://github.com/lunduniversity/introprog/assets/27621620/e8f3cb00-8315-4296-a812-85ca881d7885)
