### PR TITLE
Removed override modifer from exercise in W10

### DIFF
--- a/compendium/modules/w10-inheritance-exercise.tex
+++ b/compendium/modules/w10-inheritance-exercise.tex
@@ -290,7 +290,7 @@ I fig. \ref{snake:fig:pairs-uml} visas en bild av klasshierarkin som du steg-fö
 
 \Subtask Öppna en editor och koda \code{trait Pair[T]} i en fil \code{pairs.scala}. Lägg dessutom till en konkret metod \code{tuple} i \code{Pair[T]} som returnerar en 2-tupel med de båda elementen i paret, så att det vid behov går att omvandla \code{Pair}-instanser till 2-tupler. Använd REPL via \code{sbt console} för att testa att detta fungerar:
 \begin{REPLnonum}
-scala> val p = new Pair[Int] { override val x = 10; override val y = 20 }
+scala> val p = new Pair[Int] { val x = 10; val y = 20 }
 p: Pair[Int]{val x: Int; val y: Int} = $anon$1@784223e9
 
 scala> p.tuple


### PR DESCRIPTION
![image](https://github.com/lunduniversity/introprog/assets/27621620/3c235c09-a237-446e-b6ac-17029be16061)
The override modifier is not needed in this case because attributes x and y are not implemented in type Pair. 