### PR TITLE
Add info about string interning in slide J.1.67 fix #783

### DIFF
--- a/slides/body/lect-wjava-body.tex
+++ b/slides/body/lect-wjava-body.tex
@@ -1831,6 +1831,11 @@ scala> "hej".compareTo("hej")
 scala> "hej".compareTo("HEJ")         // alla stora är 'före' alla små
 scala> "HEJ".compareTo("hej")
 \end{REPL}
+
+\item Observera att \code{"hej" == "hej"} i Java ibland evalueras till \code{true}. Detta beror inte på att \code{==} testar innehållslikhet utan på något som kallas stränginternalisering (eng. \textit{string interning}). \\
+Mer om stränginternalisering för den nyfikna: \\
+\href{https://stackoverflow.com/questions/10578984/what-is-java-string-interning}{https://stackoverflow.com/questions/10578984/what-is-java-string-interning}
+
 \end{itemize}
 
 \href{http://docs.oracle.com/javase/8/docs/api/java/lang/String.html#compareTo-java.lang.String-}{docs.oracle.com/javase/8/docs/api/java/lang/String.html\#compareTo-java.lang.String-}


### PR DESCRIPTION
Add info about string interning in slide J.1.67 fix #783. Please observe that this fix creates another issue, i.e. overfull vbox for slide J.1.67. Consider addressing this by creating new slide and restructuring text between J.1.67 and J.1.68 and this new slide.