### PR TITLE
Add ??? to skeleton code in lab W04

### DIFF
--- a/compendium/modules/w04-objects-lab.tex
+++ b/compendium/modules/w04-objects-lab.tex
@@ -80,10 +80,11 @@ package blockmole
 
 object Color:
   // Skapar olika färger som behövs i övriga moduler
-
+  ???
 
 object BlockWindow:
   // Har ett introprog.PixelWindow och ritar blockgrafik
+  ???
 
 object Mole: // Representerar en blockmullvad som kan gräva
   def dig(): Unit = println("Här ska det grävas!")
@@ -96,7 +97,7 @@ object Main:
     Mole.dig()
 \end{Code}
 
-\noindent Skapa programskelettet ovan i filen \code{blockmole.scala} och se till att koden kompilerar utan fel och går att köra med utskrifter som förväntat.
+\noindent Skapa programskelettet ovan i filen \code{blockmole.scala} och se till att koden kompilerar utan fel och går att köra med utskrifter som förväntat. Funktionen \code{???} i skelettet används som platshållare för att koden ska kunna kompileras trots att singelobjektens kroppar just nu är tomma (mer om detta i kapitel 5).  Byt ut \code{???} mot den faktiska koden för Color och BlockWindow i kommande deluppgifter.
 
 Vi lägger i denna laboration alla moduler i samma fil, men i andra situationer när  modulerna blir stora och/eller ska återanvändas av flera olika program är det bra att ha dem i olika filer så att de kan kompileras och testas separat.
 


### PR DESCRIPTION
There is some skeleton code provided during the lab W04 that does not compile because some singleton objects are empty. My change adds the ??? placeholder to fix this and also briefly explains the question mark function. 