### PR TITLE
update lab task 5f in w01 to clarify type

### DIFF
--- a/compendium/modules/w01-intro-lab.tex
+++ b/compendium/modules/w01-intro-lab.tex
@@ -320,7 +320,10 @@ stapel(42)
 
 \Subtask Skapa en abstraktion \code{rutnät} med lämpliga parametrar som gör att man kan rita rutnät med olika stora kvadrater och olika många kvadrater i både x- och y-led.
 
-\Subtask Generalisera dina abstraktioner \code{kvadrat} och \code{stapel} så att man kan påverka fyllfärgen och pennfärgen för kvadraterna som ritas ut. Färger i Kojo är av typen \code{Color}.
+\Subtask Generalisera dina abstraktioner \code{kvadrat} och \code{stapel} så att man kan påverka fyllfärgen och pennfärgen för kvadraterna som ritas ut. 
+
+Färgerna i Kojo är av typen \code{java.awt.Color}. Typen är tillgänglig under namnet \code{Color} eftersom namnet är importerat med \code{export java.awt.Color} i filen \code{kojo.scala} (mer om nyckelorden \code{export} och \code{import} läsvecka 4).
+
 
 \Task \emph{Växling med booleska värden.}
 

--- a/compendium/modules/w01-intro-lab.tex
+++ b/compendium/modules/w01-intro-lab.tex
@@ -322,7 +322,7 @@ stapel(42)
 
 \Subtask Generalisera dina abstraktioner \code{kvadrat} och \code{stapel} så att man kan påverka fyllfärgen och pennfärgen för kvadraterna som ritas ut. 
 
-Färgerna i Kojo är av typen \code{java.awt.Color}. Typen är tillgänglig under namnet \code{Color} eftersom namnet är importerat med \code{export java.awt.Color} i filen \code{kojo.scala} (mer om nyckelorden \code{export} och \code{import} läsvecka 4).
+Färgerna i Kojo är av typen \code{java.awt.Color}. Typen är tillgänglig under namnet \code{Color} eftersom namnet gjorts direkt tillgängligt med \code{export java.awt.Color} i filen \code{kojo.scala} (mer om nyckelorden \code{export} och \code{import} i läsvecka 4).
 
 
 \Task \emph{Växling med booleska värden.}

--- a/compendium/modules/w01-intro-lab.tex
+++ b/compendium/modules/w01-intro-lab.tex
@@ -320,7 +320,7 @@ stapel(42)
 
 \Subtask Skapa en abstraktion \code{rutnät} med lämpliga parametrar som gör att man kan rita rutnät med olika stora kvadrater och olika många kvadrater i både x- och y-led.
 
-\Subtask Generalisera dina abstraktioner \code{kvadrat} och \code{stapel} så att man kan påverka fyllfärgen och pennfärgen för kvadraterna som ritas ut.
+\Subtask Generalisera dina abstraktioner \code{kvadrat} och \code{stapel} så att man kan påverka fyllfärgen och pennfärgen för kvadraterna som ritas ut. Färger i Kojo är av typen \code{Color}.
 
 \Task \emph{Växling med booleska värden.}
 

--- a/workspace/w01_kojo/kojo.scala
+++ b/workspace/w01_kojo/kojo.scala
@@ -2,3 +2,4 @@
 //> using dep "net.kogics:kojo-lib:0.2.0,url=https://github.com/lunduniversity/introprog/releases/download/kojo-lib-0.2.0/kojo-lib-0.2.0.jar"
 
 export net.kogics.kojo.Swedish.*, padda.*, CanvasAPI.*, TurtleAPI.*
+export java.awt.Color


### PR DESCRIPTION
To generalize `kvadrat` and `stapel` so that the pen and fill color can be specified, one needs to know the type of color variables in Kojo. For students to figure the type out, they either have to study the Kojo source code or use Metals' type derivation. 

I think the type should be specified in this task to minimize confusion.