### PR TITLE
Rätta historisk felaktighet

### DIFF
--- a/slides/body/lect-w01-about.tex
+++ b/slides/body/lect-w01-about.tex
@@ -141,9 +141,9 @@ Vi \Alert{itererar} över koncepten \& \Emph{fördjupar} förståelsen \Alert{ef
   \Emph{Scala} &  \Emph{2016 (D), 2021 (C)}\\
 Java &  1997 (D), 2001 (C), InfoCom-programmet grundas\\
 Simula &  1990 (D)\\
-Pascal & 1982 (D), Datateknik-programmet grundas\\
+Pascal & 1982 (D, E), Datateknik-programmet grundas\\
 
-Algol & (F, E, ...) förhistoria med hålkortsprogrammering \\
+Fortran & (F, E, ...) förhistoria med hålkortsprogrammering \\
 \end{tabular}
 \end{table}
 \pause\vfill{\SlideFontTiny \Emph{Scalas uppfinnare} \Alert{Professor Martin Odersky} vid EPFL i Lausanne, Schweiz, har även skrivit stora delar av Java-kompilatorn, och var en gång i tiden doktorand för Prof. Niklaus Wirth, som låg bakom Algol, Pascal, Modula m.m. Första versionen av Scala kom 2004. \url{https://en.wikipedia.org/wiki/Scala_(programming_language)}}


### PR DESCRIPTION
Fortran användes som förstaspråk innan Pascal introducerades. Jag började E 1980 och skrev mitt första program i Fortran på hålkort. Detta år var det sista som hålkort användes. I fortsättningskursen användes Pascal och terminaler.
Jämfört med 1979 var det dock ett framsteg att vi fick köra inläsningen av hålkorten själva. Tidigare fick studenterna lämna in bunten i en reception som sedan läste in hålkorten och körde programmet åt en. Cykeln editera-exekvera-felsöka/förbättra var lite längre så man försökte undvika fel.
