### PR TITLE
Use modern import syntax in the words lab

### DIFF
--- a/compendium/modules/w09-setmap-lab.tex
+++ b/compendium/modules/w09-setmap-lab.tex
@@ -59,7 +59,7 @@ Dessa ofärdiga kodfiler ligger i paketet \code{nlp}:
 
 \Subtask Testa noga så att din \code{FreqMapBuilder} fungerar korrekt. Exempel på test i REPL:
 \begin{REPL}
-scala> import nlp._
+scala> import nlp.*
 
 scala> val fmb = FreqMapBuilder("hej", "på", "dej")
 fmb: nlp.FreqMapBuilder = nlp.FreqMapBuilder@458f85ef


### PR DESCRIPTION
Use `import nlp.*` instead of `import nlp._` since it is preferred in Scala 3.