### PR TITLE
Fixade så att det inte stod "windowTitel" utan "windowTitle"

### DIFF
--- a/workspace/w10_snake/Settings.scala
+++ b/workspace/w10_snake/Settings.scala
@@ -5,7 +5,7 @@ class Settings(configs: Map[String, String]):
   def getOrElse[T](key: String, default: T)(using p: Settings.Parser[T]): T = 
     configs.get(key).flatMap(p.fromString).getOrElse(default)
 
-  var windowTitle: String          = getOrElse("windowTitel", "Snake")
+  var windowTitle: String          = getOrElse("windowTitle", "Snake")
   var windowSize: (Int, Int)       = getOrElse("windowSize", (50,30))
   var blockSize: Int               = getOrElse("blockSize", 15)
   var background: Color            = getOrElse("background", Colors.Black) 


### PR DESCRIPTION
Blev strul för mig när jag skulle ladda in en test Settings fil under labben då den inte kunde hitta "windowTitle" så den gick alltid till "default värdet", men detta funkade för mig.