### PR TITLE
Fix typo in w12-assignment-photo.tex

### DIFF
--- a/compendium/modules/w12-assignment-photo.tex
+++ b/compendium/modules/w12-assignment-photo.tex
@@ -132,7 +132,7 @@ Du ska bygga vidare på givna koden i \code{Filter.scala} som visas nedan. Du sk
 \begin{figure}
 \centering
 \includegraphics[width=0.8\textwidth]{../img/w12-assignment-photo/photo-jay-sobel.png}
-\caption{Bildredigeringsfönstret med alla filter implementerade. Ett kontruförstärkande så kallat Sobel-filter är applicerat med tröskelvärde 150.}
+\caption{Bildredigeringsfönstret med alla filter implementerade. Ett konturförstärkande så kallat Sobel-filter är applicerat med tröskelvärde 150.}
 \label{photo:fig:photo-jay-sobel}
 \end{figure}
 


### PR DESCRIPTION
Change "kontruförstärkande" to "konturförstärkande"