### PR TITLE
autotranslate: Option-D code clamps (lect-w10) + apply-b0d hardening

### DIFF
--- a/autotranslate/Latex.scala
+++ b/autotranslate/Latex.scala
@@ -218,7 +218,12 @@ object Latex:
               // so pdflatex skips it — and conditional skip-scanning never expands the content, making
               // this a robust escape hatch for build-breaking constructs. An optional \else branch
               // (English replacement) rides along verbatim and shows on the English side.
-              val e = matchFi(text, j)
+              // Absorb a trailing `{}` (the space-guard emitted by inline clamps, since `\fi` is a control
+              // word and TeX would swallow a following space -> "Xoch"). Keeping it INSIDE this one span
+              // means an inline clamp masks to a SINGLE placeholder exactly like the bare \code{} it
+              // replaced, so a clamped prose unit keeps the same cache key (stays a model-free cache hit).
+              var e = matchFi(text, j)
+              if e + 1 < n && text(e) == '{' && text(e + 1) == '}' then e += 2
               protect(text.substring(i, e)); i = e
             case nm if verbatimInline.contains(nm) =>
               var k = j

--- a/autotranslate/scratch/apply-b0d.scala
+++ b/autotranslate/scratch/apply-b0d.scala
@@ -153,17 +153,24 @@ object Apply:
       b += s(i); i += 1
       while i < n && s(i) != q do { if s(i)=='\\' && i+1 < n then { b += s(i); i += 1 }; if i < n then { b += s(i); i += 1 } }
       if i < n then { b += s(i); i += 1 }
+    // idiomatic dispatch on a 3-char lookahead (JohanbcEkberg's review suggestion, PR #940): Option via
+    // `lift` removes the manual i+1/i+2 bounds checks. Case order matters: // before /*, """ before ".
     while i < n do
-      val c = s(i)
-      if c == '/' && i+1 < n && s(i+1) == '/' then { while i < n && s(i) != '\n' do i += 1 }
-      else if c == '/' && i+1 < n && s(i+1) == '*' then { i += 2; while i+1 < n && !(s(i)=='*'&&s(i+1)=='/') do i += 1; i += 2 }
-      else if c == '"' && i+2 < n && s(i+1)=='"' && s(i+2)=='"' then
-        b ++= "\"\"\""; i += 3
-        while i+2 < n && !(s(i)=='"'&&s(i+1)=='"'&&s(i+2)=='"') do { b += s(i); i += 1 }
-        if i+2 < n then { b ++= "\"\"\""; i += 3 } else while i < n do { b += s(i); i += 1 }
-      else if c == '"' then copyDelimited('"')
-      else if c == '\'' then copyDelimited('\'')
-      else { b += c; i += 1 }
+      (s.lift(i), s.lift(i + 1), s.lift(i + 2)) match
+        case (Some('/'), Some('/'), _) =>
+          while i < n && s(i) != '\n' do i += 1
+        case (Some('/'), Some('*'), _) =>
+          i += 2
+          while i + 1 < n && !(s(i) == '*' && s(i + 1) == '/') do i += 1
+          i += 2
+        case (Some('"'), Some('"'), Some('"')) =>
+          b ++= "\"\"\""; i += 3
+          while i + 2 < n && !(s(i) == '"' && s(i + 1) == '"' && s(i + 2) == '"') do { b += s(i); i += 1 }
+          if i + 2 < n then { b ++= "\"\"\""; i += 3 } else while i < n do { b += s(i); i += 1 }
+        case (Some('"'), _, _)  => copyDelimited('"')
+        case (Some('\''), _, _) => copyDelimited('\'')
+        case (Some(c), _, _)    => b += c; i += 1
+        case _                  => i += 1 // unreachable (loop guard ensures s.lift(i) is Some)
     b.toString
 
   private val slideBegin = raw"(?s)^\\begin\{(Slide|SlideExtra|SlideSimple)\}".r

--- a/autotranslate/scratch/apply-b0d.scala
+++ b/autotranslate/scratch/apply-b0d.scala
@@ -36,6 +36,10 @@ object Glossary:
     // "bastyp"/"subtyp" (concepts, translated as prose). render() only touches code spans, so these
     // rename the CODE identifiers only, never the prose term.
     "Bastyp" -> "BaseType", "Subtyp1" -> "Subtype1", "Subtyp2" -> "Subtype2",
+    // lect-w10-extends demo identifiers (BR-ratified this session): encapsulation + inheritance examples.
+    // gEllerT = "Gurka eller Tomat" -> cOrT (Cucumber or Tomato); minHemlis/avslöjad = secret/reveal demo.
+    "gEllerT" -> "cOrT", "minHemlis" -> "mySecret", "vårHemlis" -> "ourSecret", "avslöjad" -> "revealed",
+    "pris" -> "price", "alternativ" -> "alternative", "StorGurkan" -> "BigCucumber",
     // CARDS cluster (w06-patterns) — BR-RATIFIED 2026-06-30 (sameColourSuit + Färg->Suit confirmed).
     // NOTE: Färg->Suit is CARDS-CONTEXT-ONLY; a kojo/colour file needs Färg->Colour (apply per-context).
     "Färg" -> "Suit", "Kortlek" -> "Deck",
@@ -52,6 +56,12 @@ object Glossary:
     "gurka är gott ibland..." -> "cucumber is tasty sometimes...",
     "Skalas med skalare." -> "Peeled with a peeler.",
     "Skållas." -> "Blanched.",  // BR: culinary term for peeling tomatoes (skålla = blanch), not "scald"
+    // lect-w10-extends output/string data (BR-ratified this session). Applied everywhere in a span, so they
+    // cover both the string literal and the REPL echo (e.g. `println(" Städa Städa")` + `... Städa Städa`).
+    "Det går precis lika bra med selleri!" -> "Celery works just as well!",
+    "kan kanske också funka med en betongpelare" -> "could maybe also work with a concrete pillar",
+    "Error: p är ej student; program saknas" -> "Error: p is not a student; program missing",
+    "Städa" -> "Clean", "Prata" -> "Talk", "hej" -> "hi",
   ).sortBy(-_._1.length)
 
   private val tok: Regex = "[A-Za-zÅÄÖåäö_][A-Za-z0-9ÅÄÖåäö_]*".r
@@ -92,6 +102,8 @@ object Allow:
     // Scala stdlib + English words the dict misses, and all-lowercase LaTeX listing/font option keys
     // captured from code-env optional args (\begin{Code}[basicstyle=...\ttfamily\selectfont]) — never Swedish:
     "println", "instantiated", "basicstyle", "ttfamily", "selectfont", "numberstyle",
+    // proper nouns kept verbatim in examples (BR): a personal-name demo, not a translatable identifier.
+    "björn",
   )
   private def subwords(s: String): Iterator[String] =
     "[A-Za-zÅÄÖåäö_]+".r.findAllIn(s).iterator
@@ -222,7 +234,25 @@ object Apply:
     val fallVocab = fall.toSeq.sortBy { case (w, n) => (-n, w) }
     (Latex.restore(masked, spans2.toVector), clamped.toSeq, skipped.toSeq, fallVocab, suppressed.toSeq)
 
+/** COMPILE GATE (--verify-examples <file.scala>...): render each given .scala through the SAME Glossary and
+  * compile them together (one scala-cli invocation). "Only compilable code should pass": a glossary rename is
+  * accepted only if the English programs still compile. Pass the self-contained, glossary-relevant files that
+  * form one compilation unit (e.g. vego1.scala + vego1Test.scala, which imports exempelVego1.*) so cross-file
+  * renames are verified consistent. Prints the compiler diagnostics and a PASS/FAIL verdict. */
+def verifyExamples(files: Seq[os.Path]): Unit =
+  val tmp = os.temp.dir(prefix = "b0d-verify")
+  for f <- files do os.write.over(tmp / f.last, Glossary.render(os.read(f)))
+  println(s"rendered ${files.size} .scala files -> $tmp; compiling with scala-cli...")
+  val r = os.proc("scala-cli", "compile", "--server=false", tmp.toString)
+    .call(check = false, mergeErrIntoOut = true, stdout = os.Pipe)
+  r.out.text().linesIterator
+    .filterNot(l => Seq("Checking", "Checked", "Downloading", "Downloaded", "Compiling", "project root").exists(l.contains))
+    .filter(_.trim.nonEmpty).take(40).foreach(println)
+  println(if r.exitCode == 0 then s"COMPILE OK — ${files.size} rendered example files compile"
+          else s"COMPILE FAILED (exit ${r.exitCode}) — glossary rename breaks the English project")
+
 @main def run(args: String*): Unit =
+  if args.headOption.contains("--verify-examples") then { verifyExamples(args.tail.map(a => os.Path(a, os.pwd))); return }
   val file = os.Path(args.head, os.pwd)
   val write = args.contains("--write")
   val src = os.read(file)

--- a/autotranslate/scratch/apply-b0d.scala
+++ b/autotranslate/scratch/apply-b0d.scala
@@ -129,9 +129,12 @@ object Apply:
     case "inline" => inlineInner(span)
     case "env"    => envRe.findPrefixMatchOf(span).map(_.group(2)).getOrElse("")
     case _        => ""
+  // NB: `\fi` is a control WORD, so TeX swallows the space that follows it -- `...\fi och` renders "Xoch".
+  // Append `{}` after `\fi` so an existing following space is preserved (and none is added before
+  // punctuation). Verified: `\fi and` -> "Band", `\fi{} and` -> "B and". Applies to BOTH builds.
   def clamp(sv: String, en: String, k: String): String = k match
-    case "inline" => s"\\ifswedish$sv\\else$en\\fi"
-    case "env"    => s"\\ifswedish\n$sv\n\\else\n$en\n\\fi"
+    case "inline" => s"\\ifswedish$sv\\else$en\\fi{}"
+    case "env"    => s"\\ifswedish\n$sv\n\\else\n$en\n\\fi{}"
     case _        => sv
 
   // Strip //-comments and /* */ comments (only) for the leak GATE, but KEEP string/char literals. Comment

--- a/autotranslate/scratch/apply-b0d.scala
+++ b/autotranslate/scratch/apply-b0d.scala
@@ -153,17 +153,20 @@ object Apply:
 
   private val slideBegin = raw"(?s)^\\begin\{(Slide|SlideExtra|SlideSimple)\}".r
   private val slideEnd   = raw"(?s)^\\end\{(Slide|SlideExtra|SlideSimple)\}".r
-  private case class Info(k: String, sv: String, en: String, clean: Boolean, susp: Seq[String], group: Int)
+  // clampable = has a real rename AND no residual suspect Swedish; susp = un-clampable Swedish identifiers/output
+  private case class Info(k: String, sv: String, en: String, clampable: Boolean, susp: Seq[String], group: Int)
 
   /** returns (out, clamped[sv,en], skipped[preview,suspects], fallthroughVocab[token,count], suppressed[preview]).
-    * SLIDE-LEVEL gating: a candidate unit is clamped only if its rendered English is allowlist-clean AND every
-    * other translatable code unit on the SAME \begin{Slide}...\end{Slide} is also clean. This prevents mixed-
-    * language slides (define-in-English / use-in-Swedish) under partial glossary coverage -- a slide clamps
-    * all-or-nothing. Units OUTSIDE any slide (e.g. compendium continuous text) fall back to per-unit. A clean
-    * unit held back because a slide-mate is dirty is reported as `suppressed` (the coupling cost / worklist). */
+    * SLIDE-LEVEL gating: a candidate unit is clamped only if it is clampable AND no other unit on the SAME
+    * \begin{Slide}...\end{Slide} has residual (un-clampable) Swedish. This prevents mixed-language slides
+    * (define-in-English / use-in-Swedish) under partial glossary coverage -- a slide clamps all-or-nothing.
+    * Units OUTSIDE any slide (e.g. compendium continuous text) fall back to per-unit. A clampable unit held
+    * back because a slide-mate is dirty is reported as `suppressed` (the coupling cost / worklist).
+    * A unit with NOTHING to translate (no glossary id, only a downstream-handled comment) is neither clamped
+    * nor dirtying -- it is benign and left as-is. */
   def apply(src: String): (String, Seq[(String, String)], Seq[(String, Seq[String])], Seq[(String, Int)], Seq[String]) =
     val (masked, spans, _) = Latex.mask(src, stripEng = false)
-    // ---- pass 1: analyse each span (candidate?/clean?/suspects) and assign a slide-group id (-1 = outside) ----
+    // ---- pass 1: analyse each span (candidate?/clampable?/suspects) and assign a slide-group id (-1 = outside) ----
     val infos = new Array[Info](spans.size)
     var gid = -1; var cur = -1
     for idx <- spans.indices do
@@ -177,9 +180,12 @@ object Apply:
           if !(Code.swedishish(c) || Glossary.touches(s)) then Info("", s, s, false, Nil, cur)
           else
             val en = Glossary.render(s)
-            val gateBody = stripComments(Glossary.render(c)) // gate ignores comments (downstream); strings kept
-            val clean = en != s && Allow.isClean(gateBody)
-            Info(k, s, en, clean, if clean then Nil else Allow.suspects(gateBody), cur)
+            // gate ignores comments (downstream) but keeps strings; also drop REPL object-identity hashcodes
+            // (`Gurka@15f11bfb`, `A@5faeada1`) whose hex letter-runs (bfb/faeada/eee) are nondeterministic junk,
+            // not Swedish. `@tailrec`/`@main` survive (a non-hex letter stops the match).
+            val gateBody = stripComments(Glossary.render(c)).replaceAll("@[0-9a-fA-F]+", "")
+            val susp = Allow.suspects(gateBody)
+            Info(k, s, en, en != s && susp.isEmpty, susp, cur)
       if slideEnd.findPrefixMatchOf(s).isDefined then cur = -1
     // Swedish glossary identifier sitting in a code-display context we CANNOT clamp: a \code/\texttt/\lstinline
     // inside a masked-whole span (tikzpicture is a verbatimEnv, \texttt is maskWhole) — the tool never sees it
@@ -189,9 +195,10 @@ object Apply:
     def codeDisplaySwedish(s: String): Boolean =
       Glossary.touches(s) &&
         Seq("\\code", "\\jcode", "\\lstinline", "\\verb", "\\texttt").exists(s.contains)
-    // a slide-group is un-clampable if ANY candidate unit is dirty OR any non-candidate span hides code-Swedish
+    // a slide-group is dirty (un-clampable) if ANY candidate has residual suspects OR any non-candidate span
+    // hides code-Swedish. A benign candidate (nothing to translate, no suspects) does NOT dirty the slide.
     val dirtyGroups = infos.iterator.filter { in =>
-      in.group >= 0 && (if in.k.nonEmpty then !in.clean else codeDisplaySwedish(in.sv))
+      in.group >= 0 && (if in.k.nonEmpty then in.susp.nonEmpty else codeDisplaySwedish(in.sv))
     }.map(_.group).toSet
     // ---- pass 2: build output + logs ----
     val clamped = collection.mutable.ArrayBuffer[(String, String)]()
@@ -201,16 +208,16 @@ object Apply:
     val spans2 = infos.map { in =>
       if in.k.isEmpty then in.sv
       else
-        val doClamp = if in.group >= 0 then in.clean && !dirtyGroups.contains(in.group) else in.clean
+        val doClamp = in.clampable && (in.group < 0 || !dirtyGroups.contains(in.group))
         val c = content(in.sv, in.k)
         if doClamp then
           clamped += ((c.replace("\n", "⏎").take(70), content(in.en, in.k).replace("\n", "⏎").take(70)))
           clamp(in.sv, in.en, in.k)
         else
-          if in.clean then suppressed += c.replace("\n", "⏎").take(70) // clean, but a slide-mate is dirty
-          else if in.susp.nonEmpty || Code.swedishish(c) then
+          if in.clampable then suppressed += c.replace("\n", "⏎").take(70) // clampable, but a slide-mate is dirty
+          else if in.susp.nonEmpty then
             skipped += ((c.replace("\n", "⏎").take(70), in.susp)); in.susp.foreach(w => fall(w) += 1)
-          in.sv
+          in.sv // benign (nothing to translate) or dirty -> keep original
     }
     val fallVocab = fall.toSeq.sortBy { case (w, n) => (-n, w) }
     (Latex.restore(masked, spans2.toVector), clamped.toSeq, skipped.toSeq, fallVocab, suppressed.toSeq)

--- a/autotranslate/scratch/apply-b0d.scala
+++ b/autotranslate/scratch/apply-b0d.scala
@@ -151,43 +151,75 @@ object Apply:
       else { b += c; i += 1 }
     b.toString
 
-  /** returns (out, clamped, skipped[preview, suspects], fallthroughVocab[token, count desc]).
-    * A candidate unit is CLAMPED only if its rendered English is allowlist-clean (no suspect Swedish token);
-    * otherwise it stays Swedish and its suspect tokens are logged (the fall-through BR wants tracked). */
-  def apply(src: String): (String, Seq[(String, String)], Seq[(String, Seq[String])], Seq[(String, Int)]) =
+  private val slideBegin = raw"(?s)^\\begin\{(Slide|SlideExtra|SlideSimple)\}".r
+  private val slideEnd   = raw"(?s)^\\end\{(Slide|SlideExtra|SlideSimple)\}".r
+  private case class Info(k: String, sv: String, en: String, clean: Boolean, susp: Seq[String], group: Int)
+
+  /** returns (out, clamped[sv,en], skipped[preview,suspects], fallthroughVocab[token,count], suppressed[preview]).
+    * SLIDE-LEVEL gating: a candidate unit is clamped only if its rendered English is allowlist-clean AND every
+    * other translatable code unit on the SAME \begin{Slide}...\end{Slide} is also clean. This prevents mixed-
+    * language slides (define-in-English / use-in-Swedish) under partial glossary coverage -- a slide clamps
+    * all-or-nothing. Units OUTSIDE any slide (e.g. compendium continuous text) fall back to per-unit. A clean
+    * unit held back because a slide-mate is dirty is reported as `suppressed` (the coupling cost / worklist). */
+  def apply(src: String): (String, Seq[(String, String)], Seq[(String, Seq[String])], Seq[(String, Int)], Seq[String]) =
     val (masked, spans, _) = Latex.mask(src, stripEng = false)
+    // ---- pass 1: analyse each span (candidate?/clean?/suspects) and assign a slide-group id (-1 = outside) ----
+    val infos = new Array[Info](spans.size)
+    var gid = -1; var cur = -1
+    for idx <- spans.indices do
+      val s = spans(idx)
+      if slideBegin.findPrefixMatchOf(s).isDefined then { gid += 1; cur = gid }
+      val k = kind(s)
+      infos(idx) =
+        if k.isEmpty then Info("", s, s, false, Nil, cur)
+        else
+          val c = content(s, k)
+          if !(Code.swedishish(c) || Glossary.touches(s)) then Info("", s, s, false, Nil, cur)
+          else
+            val en = Glossary.render(s)
+            val gateBody = stripComments(Glossary.render(c)) // gate ignores comments (downstream); strings kept
+            val clean = en != s && Allow.isClean(gateBody)
+            Info(k, s, en, clean, if clean then Nil else Allow.suspects(gateBody), cur)
+      if slideEnd.findPrefixMatchOf(s).isDefined then cur = -1
+    // Swedish glossary identifier sitting in a code-display context we CANNOT clamp: a \code/\texttt/\lstinline
+    // inside a masked-whole span (tikzpicture is a verbatimEnv, \texttt is maskWhole) — the tool never sees it
+    // as a candidate, so it stays Swedish in BOTH builds. If such a span shares a slide with a clamped unit the
+    // slide goes mixed (define-English / diagram-Swedish). Treat it as dirtying the slide. NOT triggered by
+    // bare prose Swedish (no code-display wrapper) -- that is translated downstream by the prose pass.
+    def codeDisplaySwedish(s: String): Boolean =
+      Glossary.touches(s) &&
+        Seq("\\code", "\\jcode", "\\lstinline", "\\verb", "\\texttt").exists(s.contains)
+    // a slide-group is un-clampable if ANY candidate unit is dirty OR any non-candidate span hides code-Swedish
+    val dirtyGroups = infos.iterator.filter { in =>
+      in.group >= 0 && (if in.k.nonEmpty then !in.clean else codeDisplaySwedish(in.sv))
+    }.map(_.group).toSet
+    // ---- pass 2: build output + logs ----
     val clamped = collection.mutable.ArrayBuffer[(String, String)]()
     val skipped = collection.mutable.ArrayBuffer[(String, Seq[String])]()
+    val suppressed = collection.mutable.ArrayBuffer[String]()
     val fall = collection.mutable.Map[String, Int]().withDefaultValue(0)
-    val spans2 = spans.map { s =>
-      val k = kind(s)
-      if k.isEmpty then s
+    val spans2 = infos.map { in =>
+      if in.k.isEmpty then in.sv
       else
-        val c = content(s, k)
-        val candidate = Code.swedishish(c) || Glossary.touches(s)
-        if !candidate then s
+        val doClamp = if in.group >= 0 then in.clean && !dirtyGroups.contains(in.group) else in.clean
+        val c = content(in.sv, in.k)
+        if doClamp then
+          clamped += ((c.replace("\n", "⏎").take(70), content(in.en, in.k).replace("\n", "⏎").take(70)))
+          clamp(in.sv, in.en, in.k)
         else
-          val en = Glossary.render(s)
-          val enBody = Glossary.render(c)
-          val gateBody = stripComments(enBody) // gate ignores comments (handled downstream); strings kept
-          if en != s && Allow.isClean(gateBody) then
-            clamped += ((c.replace("\n", "⏎").take(70), content(en, k).replace("\n", "⏎").take(70)))
-            clamp(s, en, k)
-          else
-            val susp = Allow.suspects(gateBody)
-            if susp.nonEmpty || Code.swedishish(c) then
-              skipped += ((c.replace("\n", "⏎").take(70), susp))
-              susp.foreach(w => fall(w) += 1)
-            s
+          if in.clean then suppressed += c.replace("\n", "⏎").take(70) // clean, but a slide-mate is dirty
+          else if in.susp.nonEmpty || Code.swedishish(c) then
+            skipped += ((c.replace("\n", "⏎").take(70), in.susp)); in.susp.foreach(w => fall(w) += 1)
+          in.sv
     }
     val fallVocab = fall.toSeq.sortBy { case (w, n) => (-n, w) }
-    (Latex.restore(masked, spans2), clamped.toSeq, skipped.toSeq, fallVocab)
+    (Latex.restore(masked, spans2.toVector), clamped.toSeq, skipped.toSeq, fallVocab, suppressed.toSeq)
 
 @main def run(args: String*): Unit =
   val file = os.Path(args.head, os.pwd)
   val write = args.contains("--write")
   val src = os.read(file)
-  val (out, clamped, skipped, fallVocab) = Apply(src)
+  val (out, clamped, skipped, fallVocab, suppressed) = Apply(src)
 
   // structural self-validation (same as b0.scala)
   val (m1, s1, _) = Latex.mask(out, stripEng = false)
@@ -202,7 +234,7 @@ object Apply:
   // wrapped in shell (no `> file`, no `2>/dev/null`, no `echo`). stdout stays a short summary.
   val report = new StringBuilder
   report ++= s"=== fused B0+D ${if write then "WRITE" else "dry-run"}: $file ===\n"
-  report ++= s"clamped (translated) units: ${clamped.size}   |   skipped (not fully covered): ${skipped.size}\n"
+  report ++= s"clamped (translated) units: ${clamped.size}   |   skipped (not fully covered): ${skipped.size}   |   suppressed (clean, but a slide-mate is dirty): ${suppressed.size}\n"
   report ++= s"self-validation: round-trip=$roundTrips brace=$braceOk ifswedishDelta=$ifswDelta (expect=${clamped.size}) -> ${if valOk then "OK" else "CHECK"}\n"
   report ++= s"fall-through vocabulary (distinct suspect Swedish tokens left untranslated): ${fallVocab.size}\n\n"
   // The KEY review artefact (BR): every suspect token the allowlist gate left Swedish, most-frequent first.
@@ -213,7 +245,11 @@ object Apply:
   for (sv, en) <- clamped do { report ++= s"  SV: $sv\n"; report ++= s"  EN: $en\n" }
   report ++= "\n--- skipped candidate units (blocking suspect tokens shown) ---\n"
   for (c, susp) <- skipped do { report ++= s"  UNIT: $c\n"; report ++= s"    suspects: ${susp.mkString(", ")}\n" }
+  // SLIDE-GATING coupling cost: units that ARE clean but were held back because a slide-mate is dirty.
+  // Clamping only these would create a mixed-language slide; fixing their slide's blockers (above) unlocks them.
+  report ++= "\n--- suppressed by slide-gating (clean units on a slide that has a dirty unit) ---\n"
+  for c <- suppressed do report ++= s"  UNIT: $c\n"
   val reportPath = file / os.up / os.up / os.up / "autotranslate" / "scratch" / "apply-b0d-report.txt"
   os.write.over(reportPath, report.toString)
   if write then { os.write.over(file, out); println(s"[--write] applied ${clamped.size} clamps to $file") }
-  println(s"B0+D ${if write then "WRITE" else "dry-run"}: clamped=${clamped.size} skipped=${skipped.size} fallthrough=${fallVocab.size} validation=${if valOk then "OK" else "CHECK"} -> report: ${reportPath.relativeTo(os.pwd)}")
+  println(s"B0+D ${if write then "WRITE" else "dry-run"}: clamped=${clamped.size} skipped=${skipped.size} suppressed=${suppressed.size} fallthrough=${fallVocab.size} validation=${if valOk then "OK" else "CHECK"} -> report: ${reportPath.relativeTo(os.pwd)}")

--- a/autotranslate/scratch/apply-b0d.scala
+++ b/autotranslate/scratch/apply-b0d.scala
@@ -29,6 +29,13 @@ object Glossary:
     "ärÄtvärd" -> "isWorthEating", "skörd" -> "harvest", "ätvärda" -> "worthEating", "ärÄtbar" -> "isEdible",
     "anonymGrönsak" -> "anonymousVegetable",
     "skalningsmetod" -> "peelingMethod", "skalfaktor" -> "peelFactor", "ärSkalad" -> "isPeeled", "skala" -> "peel",
+    // VEGO plural inflections used as val-names in REPL examples (lect-w10-extends).
+    "gurkor" -> "cucumbers", "vikter" -> "weights",
+    // GENERIC OO example (lect-w10-extends) — placeholder type names in the arv/subtyp illustration:
+    // `trait Bastyp` with `class Subtyp1/Subtyp2`. NOT a domain cluster; distinct from the prose words
+    // "bastyp"/"subtyp" (concepts, translated as prose). render() only touches code spans, so these
+    // rename the CODE identifiers only, never the prose term.
+    "Bastyp" -> "BaseType", "Subtyp1" -> "Subtype1", "Subtyp2" -> "Subtype2",
     // CARDS cluster (w06-patterns) — BR-RATIFIED 2026-06-30 (sameColourSuit + Färg->Suit confirmed).
     // NOTE: Färg->Suit is CARDS-CONTEXT-ONLY; a kojo/colour file needs Färg->Colour (apply per-context).
     "Färg" -> "Suit", "Kortlek" -> "Deck",
@@ -82,6 +89,9 @@ object Allow:
     // java/lib package parts + math abbreviations (false positives seen in the fall-through report):
     "java", "awt", "swing", "lang", "nio", "sql", "rgb", "nom", "denom", "div", "mul", "rem", "mod", "gcd",
     "lcm", "abs", "sqrt", "pow", "sin", "cos", "tan", "arr", "vec", "buf", "idx", "pos", "dim", "px",
+    // Scala stdlib + English words the dict misses, and all-lowercase LaTeX listing/font option keys
+    // captured from code-env optional args (\begin{Code}[basicstyle=...\ttfamily\selectfont]) — never Swedish:
+    "println", "instantiated", "basicstyle", "ttfamily", "selectfont", "numberstyle",
   )
   private def subwords(s: String): Iterator[String] =
     "[A-Za-zÅÄÖåäö_]+".r.findAllIn(s).iterator
@@ -112,24 +122,33 @@ object Apply:
     case "env"    => s"\\ifswedish\n$sv\n\\else\n$en\n\\fi"
     case _        => sv
 
-  // Strip //-comments, /* */ comments, and string literals so the leak GATE sees CODE IDENTIFIERS ONLY.
-  // Comment/string Swedish is translated DOWNSTREAM by translateCodeEnvBodies inside the \else branch (see
-  // Translate.scala: "composes with apply-b0d clamps: it also translates the comments inside an \else"), so
-  // it must NOT block an identifier clamp. This was the w10-extends false-skip: a Swedish comment
-  // `// implementation saknas, inget =` skipped a fully-glossaried trait/case-class block, leaving that
-  // \begin{Code} Swedish while its adjacent (comment-free) REPL clamped to English — a mixed-language slide.
-  // NOTE: REPL *output* text and prose are NOT string literals, so stripCode keeps them and they still gate
-  // (correct — Code.translate translates comments + string literals, but not bare REPL output).
-  def stripCode(s: String): String =
+  // Strip //-comments and /* */ comments (only) for the leak GATE, but KEEP string/char literals. Comment
+  // Swedish is translated DOWNSTREAM by translateCodeEnvBodies inside the \else branch (see Translate.scala:
+  // "composes with apply-b0d clamps: it also translates the comments inside an \else"), so it must NOT block
+  // an identifier clamp -- this fixes the w10-extends false-skip where a Swedish comment
+  // `// implementation saknas, inget =` skipped a fully-glossaried trait/case-class block.
+  // Strings are KEPT deliberately: render() renames identifier tokens even INSIDE a string literal, so a
+  // Swedish word used as string DATA (e.g. the n-gram demo Vector("fem","gurkor","aer",...)) gets half-
+  // renamed to "cucumbers" while "fem"/"aer" stay Swedish. Keeping strings in the gate lets that residual
+  // Swedish block the clamp (a skipped unit outputs the ORIGINAL, discarding the partial render). String-
+  // aware so a `//` inside a string literal is not mistaken for a comment.
+  def stripComments(s: String): String =
     val b = new StringBuilder; var i = 0; val n = s.length
+    def copyDelimited(q: Char): Unit = // append a "..." or '...' literal verbatim (handles \-escapes)
+      b += s(i); i += 1
+      while i < n && s(i) != q do { if s(i)=='\\' && i+1 < n then { b += s(i); i += 1 }; if i < n then { b += s(i); i += 1 } }
+      if i < n then { b += s(i); i += 1 }
     while i < n do
       val c = s(i)
       if c == '/' && i+1 < n && s(i+1) == '/' then { while i < n && s(i) != '\n' do i += 1 }
       else if c == '/' && i+1 < n && s(i+1) == '*' then { i += 2; while i+1 < n && !(s(i)=='*'&&s(i+1)=='/') do i += 1; i += 2 }
-      else if c == '"' && i+2 < n && s(i+1)=='"' && s(i+2)=='"' then { i += 3; while i+2 < n && !(s(i)=='"'&&s(i+1)=='"'&&s(i+2)=='"') do i += 1; i += 3 }
-      else if c == '"' then { i += 1; while i < n && s(i) != '"' do { if s(i)=='\\' then i += 1; i += 1 }; i += 1 }
-      else if c == '\'' then { i += 1; while i < n && s(i) != '\'' do { if s(i)=='\\' then i += 1; i += 1 }; i += 1; b.append(' ') }
-      else { b.append(c); i += 1 }
+      else if c == '"' && i+2 < n && s(i+1)=='"' && s(i+2)=='"' then
+        b ++= "\"\"\""; i += 3
+        while i+2 < n && !(s(i)=='"'&&s(i+1)=='"'&&s(i+2)=='"') do { b += s(i); i += 1 }
+        if i+2 < n then { b ++= "\"\"\""; i += 3 } else while i < n do { b += s(i); i += 1 }
+      else if c == '"' then copyDelimited('"')
+      else if c == '\'' then copyDelimited('\'')
+      else { b += c; i += 1 }
     b.toString
 
   /** returns (out, clamped, skipped[preview, suspects], fallthroughVocab[token, count desc]).
@@ -150,7 +169,7 @@ object Apply:
         else
           val en = Glossary.render(s)
           val enBody = Glossary.render(c)
-          val gateBody = stripCode(enBody) // gate on identifiers only; comments/strings handled downstream
+          val gateBody = stripComments(enBody) // gate ignores comments (handled downstream); strings kept
           if en != s && Allow.isClean(gateBody) then
             clamped += ((c.replace("\n", "⏎").take(70), content(en, k).replace("\n", "⏎").take(70)))
             clamp(s, en, k)

--- a/autotranslate/scratch/apply-b0d.scala
+++ b/autotranslate/scratch/apply-b0d.scala
@@ -112,6 +112,26 @@ object Apply:
     case "env"    => s"\\ifswedish\n$sv\n\\else\n$en\n\\fi"
     case _        => sv
 
+  // Strip //-comments, /* */ comments, and string literals so the leak GATE sees CODE IDENTIFIERS ONLY.
+  // Comment/string Swedish is translated DOWNSTREAM by translateCodeEnvBodies inside the \else branch (see
+  // Translate.scala: "composes with apply-b0d clamps: it also translates the comments inside an \else"), so
+  // it must NOT block an identifier clamp. This was the w10-extends false-skip: a Swedish comment
+  // `// implementation saknas, inget =` skipped a fully-glossaried trait/case-class block, leaving that
+  // \begin{Code} Swedish while its adjacent (comment-free) REPL clamped to English — a mixed-language slide.
+  // NOTE: REPL *output* text and prose are NOT string literals, so stripCode keeps them and they still gate
+  // (correct — Code.translate translates comments + string literals, but not bare REPL output).
+  def stripCode(s: String): String =
+    val b = new StringBuilder; var i = 0; val n = s.length
+    while i < n do
+      val c = s(i)
+      if c == '/' && i+1 < n && s(i+1) == '/' then { while i < n && s(i) != '\n' do i += 1 }
+      else if c == '/' && i+1 < n && s(i+1) == '*' then { i += 2; while i+1 < n && !(s(i)=='*'&&s(i+1)=='/') do i += 1; i += 2 }
+      else if c == '"' && i+2 < n && s(i+1)=='"' && s(i+2)=='"' then { i += 3; while i+2 < n && !(s(i)=='"'&&s(i+1)=='"'&&s(i+2)=='"') do i += 1; i += 3 }
+      else if c == '"' then { i += 1; while i < n && s(i) != '"' do { if s(i)=='\\' then i += 1; i += 1 }; i += 1 }
+      else if c == '\'' then { i += 1; while i < n && s(i) != '\'' do { if s(i)=='\\' then i += 1; i += 1 }; i += 1; b.append(' ') }
+      else { b.append(c); i += 1 }
+    b.toString
+
   /** returns (out, clamped, skipped[preview, suspects], fallthroughVocab[token, count desc]).
     * A candidate unit is CLAMPED only if its rendered English is allowlist-clean (no suspect Swedish token);
     * otherwise it stays Swedish and its suspect tokens are logged (the fall-through BR wants tracked). */
@@ -130,11 +150,12 @@ object Apply:
         else
           val en = Glossary.render(s)
           val enBody = Glossary.render(c)
-          if en != s && Allow.isClean(enBody) then
+          val gateBody = stripCode(enBody) // gate on identifiers only; comments/strings handled downstream
+          if en != s && Allow.isClean(gateBody) then
             clamped += ((c.replace("\n", "⏎").take(70), content(en, k).replace("\n", "⏎").take(70)))
             clamp(s, en, k)
           else
-            val susp = Allow.suspects(enBody)
+            val susp = Allow.suspects(gateBody)
             if susp.nonEmpty || Code.swedishish(c) then
               skipped += ((c.replace("\n", "⏎").take(70), susp))
               susp.foreach(w => fall(w) += 1)

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-import org.bouncycastle.pqc.jcajce.provider.lms.LMSSignatureSpi.generic
 import sbt._
 import Process._
 import Keys._

--- a/slides/body/lect-w10-extends.tex
+++ b/slides/body/lect-w10-extends.tex
@@ -196,6 +196,7 @@ class Player(val snake: Snake)
 \end{Slide}
 
 \begin{Slide}{Behovet av gemensam bastyp}\SlideFontSmall
+\ifswedish
 \begin{REPLsmall}
 scala> case class Gurka(vikt: Int)
 
@@ -216,10 +217,33 @@ scala> grönsaker.map(_.vikt)
   |              ^^^^^^
   |              value vikt is not a member of Gurka | Tomat
 \end{REPLsmall}
-Hur får vi detta att fungera som vi vill? \pause\\$\rightarrow$ Skapa en bastyp \Emph{bastyp} med gemensamt attribut \code{vikt}!
+\else
+\begin{REPLsmall}
+scala> case class Cucumber(weight: Int)
+
+scala> case class Tomato(weight: Int)
+
+scala> val cucumbers = Vector(Cucumber(200), Cucumber(300))
+val cucumbers: Vector[Cucumber] = Vector(Cucumber(200), Cucumber(300))
+
+scala> cucumbers.map(_.weight)
+res0: Vector[Int] = Vector(200, 300)
+
+scala> val vegetables = Vector(Cucumber(200), Tomato(42))
+val vegetables: Vector[Cucumber | Tomato] = Vector(Cucumber(200), Tomato(42))
+
+scala> vegetables.map(_.weight)
+-- [E008] Not Found Error: --------------------------
+1 |vegetables.map(_.weight)
+  |              ^^^^^^
+  |              value weight is not a member of Cucumber | Tomato
+\end{REPLsmall}
+\fi{}
+Hur får vi detta att fungera som vi vill? \pause\\$\rightarrow$ Skapa en bastyp \Emph{bastyp} med gemensamt attribut \ifswedish\code{vikt}\else\code{weight}\fi{}!
 \end{Slide}
 
 \begin{Slide}{Varför syns inte gemensam medlem i en typunion?}
+\ifswedish
 \begin{REPLsmall}
 scala> val grönsaker = Vector(Gurka(200), Tomat(42))
 val grönsaker: Vector[Gurka | Tomat] = Vector(Gurka@15f11bfb,Tomat@16a499d1)
@@ -230,12 +254,25 @@ scala> grönsaker.map(_.vikt)
   |              ^^^^^^
   |              value vikt is not a member of Gurka | Tomat
 \end{REPLsmall}
+\else
+\begin{REPLsmall}
+scala> val vegetables = Vector(Cucumber(200), Tomato(42))
+val vegetables: Vector[Cucumber | Tomato] = Vector(Cucumber@15f11bfb,Tomato@16a499d1)
+
+scala> vegetables.map(_.weight)
+-- [E008] Not Found Error: --------------------------
+1 |vegetables.map(_.weight)
+  |              ^^^^^^
+  |              value weight is not a member of Cucumber | Tomato
+\end{REPLsmall}
+\fi{}
 \begin{itemize}\SlideFontSmall
-  \item Typerna \code{Grönsak} och \code{Tomat} är \Alert{orelaterade}. (\code{AnyRef} saknar \code{vikt})
+  \item Typerna \ifswedish\code{Grönsak}\else\code{Vegetable}\fi{} och \ifswedish\code{Tomat}\else\code{Tomato}\fi{} är \Alert{orelaterade}. (\code{AnyRef} saknar \ifswedish\code{vikt}\else\code{weight}\fi{})
   \item En medlem som råkar ha samma namn har inte alltid samma innebörd.
   \item I Scala måste du explicit relatera medlemmarna genom \Emph{arv} av bastyp med gemensam medlem, eller så får du \Alert{matcha} på unionens delar. 
   \pause\item Du kan erbjuda en sådan matchning som en \Emph{extensionsmetod}:
 \end{itemize}
+\ifswedish
 \begin{REPLsmall}
 scala> extension (gEllerT: Gurka | Tomat) def vikt = gEllerT match
          case g: Gurka => g.vikt
@@ -244,6 +281,16 @@ scala> extension (gEllerT: Gurka | Tomat) def vikt = gEllerT match
 scala> val vikter = grönsaker.map(_.vikt)
 val vikter: Vector[Int] = Vector(200, 42)
 \end{REPLsmall}
+\else
+\begin{REPLsmall}
+scala> extension (cOrT: Cucumber | Tomato) def weight = cOrT match
+         case g: Cucumber => g.weight
+         case t: Tomato => t.weight
+
+scala> val weights = vegetables.map(_.weight)
+val weights: Vector[Int] = Vector(200, 42)
+\end{REPLsmall}
+\fi{}
 \end{Slide}
 
 
@@ -291,7 +338,8 @@ Bastyp som ej ska instansieras direkt är \Alert{abstrakt} (visas med \emph{kurs
 
 
 \begin{Slide}{Skapa en gemensam bastyp med \texttt{trait} och \texttt{extends}}\SlideFontSmall
-Med en \code{trait Grönsak} kan klasserna \code{Gurka} och \code{Tomat} få en gemensam abstrakt \Emph{bastyp} genom att båda \Emph{subtyperna} gör \code{extends Grönsak}:
+Med en \ifswedish\code{trait Grönsak}\else\code{trait Vegetable}\fi{} kan klasserna \ifswedish\code{Gurka}\else\code{Cucumber}\fi{} och \ifswedish\code{Tomat}\else\code{Tomato}\fi{} få en gemensam abstrakt \Emph{bastyp} genom att båda \Emph{subtyperna} gör \ifswedish\code{extends Grönsak}\else\code{extends Vegetable}\fi{}:
+\ifswedish
 \begin{REPL}
 scala> trait Grönsak
 
@@ -304,8 +352,23 @@ val grönsaker: Vector[Grönsak] = Vector(Gurka(200), Tomat(42))
 
 
 \end{REPL}
+\else
+\begin{REPL}
+scala> trait Vegetable
+
+scala> case class Cucumber(weight: Int) extends Vegetable
+
+scala> case class Tomato(weight: Int) extends Vegetable
+
+scala> val vegetables = Vector(Cucumber(200), Tomato(42))
+val vegetables: Vector[Vegetable] = Vector(Cucumber(200), Tomato(42))
+
+
+\end{REPL}
+\fi{}
 \pause
 Men det är ännu \Alert{inte} som vi vill ha det:
+\ifswedish
 \begin{REPLnonum}
 scala> grönsaker.map(_.vikt)
 -- [E008] Not Found Error: --------------------------
@@ -313,6 +376,15 @@ scala> grönsaker.map(_.vikt)
   |              ^^^^^^
   |              value vikt is not a member of Grönsak
 \end{REPLnonum}
+\else
+\begin{REPLnonum}
+scala> vegetables.map(_.weight)
+-- [E008] Not Found Error: --------------------------
+1 |vegetables.map(_.weight)
+  |              ^^^^^^
+  |              value weight is not a member of Vegetable
+\end{REPLnonum}
+\fi{}
 \end{Slide}
 
 
@@ -357,8 +429,9 @@ Placera gemensamma medlemmar i bastypen:
 
 \begin{Slide}{Placera gemensamma delar i bastypen}
 \SlideFontSmall
-Vi inkluderar det gemensamma attributet \code{val vikt} som en \Emph{abstrakt medlem} i bastypen:
+Vi inkluderar det gemensamma attributet \ifswedish\code{val vikt}\else\code{val weight}\fi{} som en \Emph{abstrakt medlem} i bastypen:
 
+\ifswedish
 \begin{Code}
 trait Grönsak:
   val vikt: Int    // implementation saknas, inget =
@@ -367,7 +440,18 @@ case class Gurka(vikt: Int) extends Grönsak
 
 case class Tomat(vikt: Int) extends Grönsak
 \end{Code}
+\else
+\begin{Code}
+trait Vegetable:
+  val weight: Int    // implementation saknas, inget =
+
+case class Cucumber(weight: Int) extends Vegetable
+
+case class Tomato(weight: Int) extends Vegetable
+\end{Code}
+\fi{}
 Nu har du explicit sagt till kompilatorn att du vill att alla grönsaker har en vikt:
+\ifswedish
 \begin{REPLsmall}
 scala> val grönsaker = Vector(Gurka(200), Tomat(42))
 val grönsaker: Vector[Grönsak] = Vector(Gurka(200), Tomat(42))
@@ -375,7 +459,16 @@ val grönsaker: Vector[Grönsak] = Vector(Gurka(200), Tomat(42))
 scala> grönsaker.map(_.vikt)
 val res0: Vector[Int] = Vector(200, 42)
 \end{REPLsmall}
-Den abstrakta medlemmen \code{vikt} i den abstrakta typen \code{Grönsak} \Emph{implementeras} i en konkret subklass, här som en klassparameter.
+\else
+\begin{REPLsmall}
+scala> val vegetables = Vector(Cucumber(200), Tomato(42))
+val vegetables: Vector[Vegetable] = Vector(Cucumber(200), Tomato(42))
+
+scala> vegetables.map(_.weight)
+val res0: Vector[Int] = Vector(200, 42)
+\end{REPLsmall}
+\fi{}
+Den abstrakta medlemmen \ifswedish\code{vikt}\else\code{weight}\fi{} i den abstrakta typen \ifswedish\code{Grönsak}\else\code{Vegetable}\fi{} \Emph{implementeras} i en konkret subklass, här som en klassparameter.
 \end{Slide}
 
 
@@ -493,12 +586,21 @@ Alla dina egna typer ingår underförstått i Scalas typhierarki:
 
 \begin{Slide}{Vad används en trait till?}
 En \code{trait} kan användas för att skapa en bastyp som kan vara hemvist för gemensamma delar hos subtyper:
+\ifswedish
 \begin{Code}
 trait Bastyp { val x = 42 }                 // Bastyp har medlemmen x
 class Subtyp1 extends Bastyp { val y = 43 } // Subtyp1 ärver x, har även y
 class Subtyp2 extends Bastyp { val z = 44 } // Subtyp2 ärver x, har även z
 \end{Code}
+\else
+\begin{Code}
+trait BaseType { val x = 42 }                 // BaseType har medlemmen x
+class Subtype1 extends BaseType { val y = 43 } // Subtype1 ärver x, har även y
+class Subtype2 extends BaseType { val z = 44 } // Subtype2 ärver x, har även z
+\end{Code}
+\fi{}
 \pause\vspace{-0.5em}
+\ifswedish
 \begin{REPLsmall}
 scala> val a = new Subtyp1
 val a: Subtyp1 = Subtyp1@51016012
@@ -517,6 +619,26 @@ scala> new Bastyp
 --Error:
   Bastyp is a trait; it cannot be instantiated
 \end{REPLsmall}
+\else
+\begin{REPLsmall}
+scala> val a = new Subtype1
+val a: Subtype1 = Subtype1@51016012
+
+scala> a.x
+val res0: Int = 42
+
+scala> a.y
+val res1: Int = 43
+
+scala> a.z
+-- Error:
+  value z is not a member of Subtype1
+
+scala> new BaseType
+--Error:
+  BaseType is a trait; it cannot be instantiated
+\end{REPLsmall}
+\fi{}
 
 \end{Slide}
 
@@ -628,6 +750,7 @@ Det \emph{finns} tillfällen när \Alert{kodduplicering} \Emph{faktiskt är att 
 
 
 \begin{Slide}{Subtypspolymorfism och dynamisk bindning}\SlideFontTiny
+\ifswedish
 \begin{Code}[basicstyle=\SlideFontSize{6.2}{7.5}\ttfamily\selectfont]
 trait Robot { def work(): Unit }
 
@@ -637,7 +760,19 @@ case class CleaningBot(name: String) extends Robot:
 case class TalkingBot(name: String) extends Robot:
   def work(): Unit = println(" Prata Prata")
 \end{Code}
+\else
+\begin{Code}[basicstyle=\SlideFontSize{6.2}{7.5}\ttfamily\selectfont]
+trait Robot { def work(): Unit }
+
+case class CleaningBot(name: String) extends Robot:
+  def work(): Unit = println(" Clean Clean")
+
+case class TalkingBot(name: String) extends Robot:
+  def work(): Unit = println(" Talk Talk")
+\end{Code}
+\fi{}
 \Emph{Polymorfism} betyder ''många former''. Referenserna r och bot nedan kan ha olika ''former'', d.v.s de kan referera till olika sorters robotar. \\ \Emph{Dynamisk bindning} innebär att körtidstypen avgör vilken metod som körs.
+\ifswedish
 \begin{REPL}[numbers=left, basicstyle=\color{white}\SlideFontSize{6.2}{7.5}\ttfamily\selectfont]
 scala> def robotDoWork(bot: Robot) = { print(bot); bot.work() }
 
@@ -651,6 +786,21 @@ scala> r = TalkingBot("C3PO")
 scala> robotDoWork(r)
 TalkingBot(C3PO) Prata Prata
 \end{REPL}
+\else
+\begin{REPL}[numbers=left, basicstyle=\color{white}\SlideFontSize{6.2}{7.5}\ttfamily\selectfont]
+scala> def robotDoWork(bot: Robot) = { print(bot); bot.work() }
+
+scala> var r: Robot = CleaningBot("Wall-E")
+
+scala> robotDoWork(r)
+CleaningBot(Wall-E) Clean Clean
+
+scala> r = TalkingBot("C3PO")
+
+scala> robotDoWork(r)
+TalkingBot(C3PO) Talk Talk
+\end{REPL}
+\fi{}
 \end{Slide}
   
   
@@ -676,6 +826,7 @@ TalkingBot(C3PO) Prata Prata
 
 
 \begin{Slide}{Protected ger synlighet begränsad till subtyper}
+\ifswedish
 \begin{REPLsmall}
 scala> trait Super:
          private val minHemlis = 42
@@ -701,6 +852,33 @@ scala> s.vårHemlis
   Access to protected value vårHemlis not permitted because enclosing object
   is not a subclass of trait Super where target is defined
 \end{REPLsmall}
+\else
+\begin{REPLsmall}
+scala> trait Super:
+         private val mySecret = 42
+         protected val ourSecret = 42
+
+scala> class Sub extends Super { def revealed = mySecret }
+- Error: Not found: mySecret
+
+scala> class Sub extends Super { def revealed = ourSecret }
+
+scala> val s = Sub()
+val s: Sub = Sub@2eee9593
+
+scala> s.revealed
+val res0: Int = 42
+
+scala> s.mySecret
+-- Error: 
+  value mySecret is not a member of Sub - did you mean s.ourSecret?
+
+scala> s.ourSecret
+-- Error: 
+  Access to protected value ourSecret not permitted because enclosing object
+  is not a subclass of trait Super where target is defined
+\end{REPLsmall}
+\fi{}
 \end{Slide}
 
 
@@ -787,11 +965,19 @@ Testa körtidstyp med \code{isInstanceOf[Typ]}. Lova kompilatorn (och ta själv 
 \scalainputlisting[numbers=left,numberstyle=,basicstyle=\small\SlideFontSize{6.2}{7.6}\ttfamily\selectfont]{../compendium/examples/workspace/w07-inherit/src/personExample3.scala}
 \ifkompendium
 \noindent Om du i stället använder \code{match} så får du både typtest och typomvanling på ett smidigt och säkert sätt:
+\ifswedish
 \begin{Code}
   p match 
     case Student(_, _, program) => println(program)
     case _ => println("Error: p är ej student; program saknas")
 \end{Code}
+\else
+\begin{Code}
+  p match 
+    case Student(_, _, program) => println(program)
+    case _ => println("Error: p is not a student; program missing")
+\end{Code}
+\fi{}
 \fi
 \end{Slide}
 
@@ -804,6 +990,7 @@ Testa körtidstyp med \code{isInstanceOf[Typ]}. Lova kompilatorn (och ta själv 
 \ifkompendium \ExplainAnonymousClass \fi
 
 Om man har en abstrakt typ med saknade implementationer kan man fylla i det som fattas i dessa i ett extra block som ''hängs på'' vid instansiering:
+\ifswedish
 \begin{REPL}
 scala> trait Grönsak { val vikt: Int }
 // defined trait Grönsak
@@ -817,6 +1004,21 @@ scala> new Grönsak    // eller Grönsak()
 scala> new Grönsak { val vikt = 42 }
 val res0: Grönsak = anon1@4e3f2908
 \end{REPL}
+\else
+\begin{REPL}
+scala> trait Vegetable { val weight: Int }
+// defined trait Vegetable
+
+scala> new Vegetable    // eller Vegetable()
+-- Error:
+1 |new Vegetable
+  |    ^^^^^^^
+  |    Vegetable is a trait; it cannot be instantiated
+
+scala> new Vegetable { val weight = 42 }
+val res0: Vegetable = anon1@4e3f2908
+\end{REPL}
+\fi{}
 Man får då vad som kallas en \Emph{anonym klass}. (I detta fall en ganska konstig grönsak som inte är någon speciell sorts grönsak, men som ändå har en vikt.)
 
 \vspace{0.5em}
@@ -864,6 +1066,7 @@ Med en förseglad typhierarki kan du bara ärva bastypen inom samma kodfil.
 
 \begin{Slide}{Förseglade typer med \texttt{sealed}}\SlideFontTiny
 Med en \code{sealed} kan du skapa en \Emph{förseglad} uppräkning:
+\ifswedish
 \begin{Code}
 sealed trait Färg(val toInt: Int)
 object Färg:
@@ -873,8 +1076,20 @@ object Färg:
   case object Ruter   extends Färg(2)
   case object Klöver  extends Färg(3)
 \end{Code}
-Nyckelordet \code{sealed} \Alert{förhindrar} vidare subtypning av \code{Färg} i \Emph{annan kodfil} och \Alert{ger varning} om matchning är ofullständig -- tips för att undvika körtidsfel.
+\else
+\begin{Code}
+sealed trait Suit(val toInt: Int)
+object Suit:
+  val values = Vector(Spades, Hearts, Diamonds, Clubs)
+  case object Spades  extends Suit(0)
+  case object Hearts extends Suit(1)
+  case object Diamonds   extends Suit(2)
+  case object Clubs  extends Suit(3)
+\end{Code}
+\fi{}
+Nyckelordet \code{sealed} \Alert{förhindrar} vidare subtypning av \ifswedish\code{Färg}\else\code{Suit}\fi{} i \Emph{annan kodfil} och \Alert{ger varning} om matchning är ofullständig -- tips för att undvika körtidsfel.
 
+\ifswedish
 \begin{REPLsmall}
 scala> Färg.values(0) match { case Färg.Spader => "hej" }
 -- Warning:
@@ -885,6 +1100,18 @@ scala> Färg.values(0) match { case Färg.Spader => "hej" }
   |It would fail on pattern case: Hjärter, Ruter, Klöver
 val res0: String = hej
 \end{REPLsmall}
+\else
+\begin{REPLsmall}
+scala> Suit.values(0) match { case Suit.Spades => "hi" }
+-- Warning:
+1 |Suit.values(0) match { case Suit.Spades => "hi" }
+  |^^^^^^^^^^^^^^
+  |match may not be exhaustive.
+  |
+  |It would fail on pattern case: Hearts, Diamonds, Clubs
+val res0: String = hi
+\end{REPLsmall}
+\fi{}
 Använd hellre \code{enum} så får du både \code{sealed} och mer godis på köpet!
 \end{Slide}
   
@@ -896,15 +1123,30 @@ Använd hellre \code{enum} så får du både \code{sealed} och mer godis på kö
 \item Om man ärver en klass får man tillgång till alla medlemmar som inte är privata och kan byta till godtycklig implementation om typerna stämmer.
 \item Detta kan vara riskabelt om den som skrivit klassen inte planerat för detta och noga dokumenterat hur klassen är tänkt att användas vid arv. 
 \item Genom att skapa \Emph{öppna klasser} med nyckelordet \code{open} signalerar du att klassen är tänkt att vara en supertyp vid arv.
+\ifswedish
 \begin{Code}
 open class Gurka(val vikt: Int, val pris: Double):
   /** Gör override på denna om du vill ha annat alternativ. */
   def alternativ: String = s"Det går precis lika bra med selleri!"  
 \end{Code}
+\else
+\begin{Code}
+open class Cucumber(val weight: Int, val price: Double):
+  /** Gör override på denna om du vill ha annat alternative. */
+  def alternative: String = s"Celery works just as well!"  
+\end{Code}
+\fi{}
+\ifswedish
 \begin{REPLsmall}
 scala> object StorGurkan extends Gurka(1000, 1_000_000): // ärv på bäst du vill!
          override def alternativ = "kan kanske också funka med en betongpelare"
 \end{REPLsmall}
+\else
+\begin{REPLsmall}
+scala> object BigCucumber extends Cucumber(1000, 1_000_000): // ärv på bäst du vill!
+         override def alternative = "could maybe also work with a concrete pillar"
+\end{REPLsmall}
+\fi{}
 \item \code{open} krävs om du vill tysta varning vid \Alert{arv från en annan kodfil}.
 \item Du kan även komma undan varningen med \code{import scala.language.adhocExtensions} 
 \end{itemize}  


### PR DESCRIPTION
Renders Swedish code identifiers as English in the `\swedishfalse` build via
`\ifswedish/\else` clamps, and hardens the `apply-b0d` clamp tool.

## apply-b0d hardening
- Gate on code **identifiers only** — comments/strings are handled downstream by
  `translateCodeEnvBodies`, so they no longer false-skip a clamp.
- Keep string literals in the gate (avoids half-translated string data).
- **Slide-level all-or-nothing gating**: a slide clamps only if every code unit
  on it is clean — structurally prevents mixed-language slides.
- `--verify-examples`: render example `.scala` through the glossary and compile
  them — only compilable code passes.
- Fix `\fi` swallowing the following space (`\fi{}`), with `Latex.mask`
  absorbing the `{}` so clamps stay cache-transparent (round-trip verified).

## Content
- `slides/body/lect-w10-extends.tex`: 30 clamps → 9 fully-English, 3 fully-
  Swedish, 0 mixed slides. Verified by rebuilding `slides-en/lect-w10-en.pdf`
  model-free from the committed cache (8.8% Swedish, down from 43%).

New glossary clusters (w10 identifiers/strings) are flagged for ratification.
