### PR TITLE
autotranslate: translate \scalainputlisting example-file identifiers (shared CodeGlossary)

### DIFF
--- a/autotranslate/Code.scala
+++ b/autotranslate/Code.scala
@@ -65,13 +65,17 @@ object Code:
     * all, and stop the per-`--all` cache churn). So skip any line whose first non-space char is `%` — copied
     * verbatim, never translated. Default false: a real `.scala` line never starts with `%` (it's modulo, an
     * infix op: `a % b`), so the raw-source path (`--codetest` / workspace) is unaffected. */
-  def translate(src: String, tr: String => String, skipTexComments: Boolean = false): String =
+  def translate(src: String, tr: String => String, skipTexComments: Boolean = false,
+      alsoTranslate: String => Boolean = _ => false): String =
     val sb = StringBuilder(); val n = src.length; var i = 0
     // translate inner text of a comment OR string only if it looks Swedish — this skips already-English
     // library comments AND commented-out code (e.g. `//val w = new LifeWindow(20, 20)`), which must NOT
     // be sent to the model (wasteful + a source of masking-leak corruption).
+    // `alsoTranslate` opens a second gate for exact human knowledge: a no-åäö Swedish string the swedishish
+    // heuristic misses (e.g. "Skalas med skalare.") still routes to `tr` if it's a known Override key, so the
+    // Override resolves it. English strings aren't Override keys, so they still never reach the model.
     def piece(s: String): String =
-      if s.exists(_.isLetter) && swedishish(s) then tr(s) else s
+      if s.exists(_.isLetter) && (swedishish(s) || alsoTranslate(s.trim)) then tr(s) else s
     def texCommentLine(k: Int): Boolean = // first non-space char of the line at k is a LaTeX `%`
       var w = k
       while w < n && (src(w) == ' ' || src(w) == '\t') do w += 1

--- a/autotranslate/CodeGlossary.scala
+++ b/autotranslate/CodeGlossary.scala
@@ -1,0 +1,125 @@
+import scala.util.matching.Regex
+
+object CodeGlossary:
+  // VEGO cluster — ratified 2026-06-30 (vegomatch.scala + vego1-4 + w06-patterns), compile-verified.
+  // whole-identifier rename (token-exact). longest keys are fine; token replace is exact-match, not substring.
+  val id: Map[String, String] = Map(
+    "Grönsak" -> "Vegetable", "grönsak" -> "vegetable", "Grönsaker" -> "Vegetables", "grönsaker" -> "vegetables",
+    "Gurka" -> "Cucumber", "gurka" -> "cucumber", "ingenGurka" -> "noCucumber",
+    "Tomat" -> "Tomato", "tomat" -> "tomato",
+    "vikt" -> "weight", "ärRutten" -> "isRotten", "rutten" -> "rotten",
+    "slumpvikt" -> "randomWeight", "slumprutten" -> "randomRotten",
+    "slumpgurka" -> "randomCucumber", "slumptomat" -> "randomTomato", "slumpgrönsak" -> "randomVegetable",
+    "slumpbroccoli" -> "randomBroccoli", // exercise variant (w06): Broccoli stays (English), slump-prefix -> random
+    "Broccoli" -> "Broccoli", // identity: keep, but listed so a half-Swedish 'slumpbroccoli' can't slip the gate
+    "ärÄtvärd" -> "isWorthEating", "skörd" -> "harvest", "ätvärda" -> "worthEating", "ärÄtbar" -> "isEdible",
+    "anonymGrönsak" -> "anonymousVegetable",
+    "skalningsmetod" -> "peelingMethod", "skalfaktor" -> "peelFactor", "ärSkalad" -> "isPeeled", "skala" -> "peel",
+    // wrapper object names of the vego example programs (compendium/examples/.../vego1-4.scala).
+    "exempelVego1" -> "exampleVego1", "exempelVego2" -> "exampleVego2",
+    "exempelVego3" -> "exampleVego3", "exempelVego4" -> "exampleVego4",
+    // VEGO plural inflections used as val-names in REPL examples (lect-w10-extends).
+    "gurkor" -> "cucumbers", "vikter" -> "weights",
+    // GENERIC OO example (lect-w10-extends) — placeholder type names in the arv/subtyp illustration:
+    // `trait Bastyp` with `class Subtyp1/Subtyp2`. NOT a domain cluster; distinct from the prose words
+    // "bastyp"/"subtyp" (concepts, translated as prose). render() only touches code spans, so these
+    // rename the CODE identifiers only, never the prose term.
+    "Bastyp" -> "BaseType", "Subtyp1" -> "Subtype1", "Subtyp2" -> "Subtype2",
+    // lect-w10-extends demo identifiers (ratified in session, pending BR confirmation): encapsulation + inheritance examples.
+    // gEllerT = "Gurka eller Tomat" -> cOrT (Cucumber or Tomato); minHemlis/avslöjad = secret/reveal demo.
+    "gEllerT" -> "cOrT", "minHemlis" -> "mySecret", "vårHemlis" -> "ourSecret", "avslöjad" -> "revealed",
+    "pris" -> "price", "alternativ" -> "alternative", "StorGurkan" -> "BigCucumber",
+    // CARDS cluster (w06-patterns) — BR-RATIFIED 2026-06-30 (sameColourSuit + Färg->Suit confirmed).
+    // NOTE: Färg->Suit is CARDS-CONTEXT-ONLY; a kojo/colour file needs Färg->Colour (apply per-context).
+    "Färg" -> "Suit", "Kortlek" -> "Deck",
+    "Spader" -> "Spades", "Hjärter" -> "Hearts", "Ruter" -> "Diamonds", "Klöver" -> "Clubs",
+    // parafärg = short for parallellfärg = the same-COLOUR suit (Spades<->Clubs black, Hearts<->Diamonds red).
+    // No standard English card term exists (verified: bridge pairs suits by colour but has no single word),
+    // so use the clearest self-documenting name. NOT "partnerSuit" (collides with bridge 'partner' = player).
+    "parafärg" -> "sameColourSuit", "parallellFärg" -> "sameColourSuit",
+    // lect-w06-matching (pattern-matching lecture) identifiers — ratified in session, pending BR confirmation.
+    "smak" -> "taste", "lök" -> "onion", "testa" -> "test", "visa" -> "show", "svans" -> "tail",
+    "livetsMening" -> "meaningOfLife", "LivetsMening" -> "MeaningOfLife", "ärLivetsMening" -> "isMeaningOfLife",
+    "ärLivetsMeningBuggig" -> "isMeaningOfLifeBuggy", "ärLivetsMeningBackTicks" -> "isMeaningOfLifeBackTicks",
+    "svar" -> "answer", "värdeAttUndersöka" -> "valueToExamine",
+    "mönster1" -> "pattern1", "mönster2" -> "pattern2", "mönster3" -> "pattern3", "mönsterN" -> "patternN",
+    "resultat1" -> "result1", "resultat2" -> "result2", "resultat3" -> "result3", "resultatN" -> "resultN",
+  )
+  // string / comment inner text (longest first so a prefix doesn't pre-empt). exact substring replace.
+  val str: Seq[(String, String)] = Seq(
+    "gurka är gott ibland..." -> "cucumber is tasty sometimes...",
+    // NB: the vego example-file knowledge strings (Skållas.->Blanched., Skalas med skalare., Antal
+    // skördade/ätvärda grönsaker:) moved to Overrides.scala — whole-unit match, resolved via Code.translate
+    // for the mirrored example files (PR #943 review). Keep only slide-clamp result strings here.
+    // lect-w10-extends output/string data (ratified in session, pending BR confirmation). Applied everywhere in a span, so they
+    // cover both the string literal and the REPL echo (e.g. `println(" Städa Städa")` + `... Städa Städa`).
+    "Det går precis lika bra med selleri!" -> "Celery works just as well!",
+    "kan kanske också funka med en betongpelare" -> "could maybe also work with a concrete pillar",
+    "Error: p är ej student; program saknas" -> "Error: p is not a student; program missing",
+    "Städa" -> "Clean", "Prata" -> "Talk", "hej" -> "hi",
+    // lect-w06-matching result/prompt strings — ratified in session, pending BR confirmation. `$`-interpolation fragments kept;
+    // sortBy(-length) ensures longer strings (e.g. "inte gott :(") replace before shorter ("gott").
+    "livets mening är funnen: " -> "the meaning of life is found: ",
+    "en rutten gurka som väger " -> "a rotten cucumber weighing ",
+    "exakt två grönsaker: " -> "exactly two vegetables: ",
+    "exakt en grönsak: " -> "exactly one vegetable: ",
+    " och sedan svansen: " -> " and then the tail: ",
+    "smakar bakvänt: " -> "tastes backwards: ",
+    "tom grönsaksvektor" -> "empty vegetable vector",
+    "okänd grönsak: " -> "unknown vegetable: ",
+    "fattas mening: " -> "missing meaning: ",
+    "Ange en grönsak" -> "Enter a vegetable",
+    "ganska gott..." -> "quite tasty...",
+    "mindre gott..." -> "less tasty...",
+    "gott ibland!" -> "tasty sometimes!",
+    "inte gott :(" -> "not tasty :(",
+    "gott, väger " -> "tasty, weighs ",
+    "först en " -> "first one ",
+    "jättegott!" -> "very tasty!",
+    "inte gott" -> "not tasty",
+    "gott!" -> "tasty!",
+    "inte " -> "not ",
+    " är " -> " is ",
+    "gott" -> "tasty",
+  ).sortBy(-_._1.length)
+
+  private val tok: Regex = "[A-Za-zÅÄÖåäö_][A-Za-z0-9ÅÄÖåäö_]*".r
+  private def renameAll(span: String): String =
+    tok.replaceAllIn(span, m => Regex.quoteReplacement(id.getOrElse(m.matched, m.matched)))
+
+  /** id rename + `str` replace over the WHOLE span (incl. inside string literals). CONTEXT-SCOPED: only for
+    * the slide clamps (apply-b0d), where the `str` list is ratified per file. NOT for corpus-wide use —
+    * `str` is a bare substring replace that half-translates partial-coverage strings and misfires on short
+    * keys ("Städa toaletter" -> "Clean toaletter", "hej" in "hejsan"). */
+  def render(span: String): String =
+    renameAll(str.foldLeft(span) { case (acc, (sv, en)) => acc.replace(sv, en) })
+
+  /** Token-exact IDENTIFIER rename applied ONLY in code regions; string/char literals and //, /* */ comments
+    * are copied VERBATIM. For mirrored example .scala/.java: identifiers get renamed, but strings/comments
+    * are left untouched so Code.translate + Overrides handle them on their natural Swedish (a knowledge
+    * string like "Skållas."->"Blanched." resolves via Overrides; nothing half-translates). No `str` here. */
+  def renderCodeIds(s: String): String =
+    val out = new StringBuilder; val code = new StringBuilder; var i = 0; val n = s.length
+    def flush(): Unit = if code.nonEmpty then { out ++= renameAll(code.toString); code.clear() }
+    def copyDelim(q: Char): Unit = // copy a "..." or '...' literal verbatim (handles \-escapes)
+      out += s(i); i += 1
+      while i < n && s(i) != q do { if s(i)=='\\' && i+1 < n then { out += s(i); i += 1 }; if i < n then { out += s(i); i += 1 } }
+      if i < n then { out += s(i); i += 1 }
+    while i < n do
+      val c = s(i)
+      if c == '/' && i+1 < n && s(i+1) == '/' then { flush(); while i < n && s(i) != '\n' do { out += s(i); i += 1 } }
+      else if c == '/' && i+1 < n && s(i+1) == '*' then
+        flush(); out ++= "/*"; i += 2
+        while i+1 < n && !(s(i)=='*'&&s(i+1)=='/') do { out += s(i); i += 1 }
+        if i+1 < n then { out ++= "*/"; i += 2 } else while i < n do { out += s(i); i += 1 }
+      else if c == '"' && i+2 < n && s(i+1)=='"' && s(i+2)=='"' then
+        flush(); out ++= "\"\"\""; i += 3
+        while i+2 < n && !(s(i)=='"'&&s(i+1)=='"'&&s(i+2)=='"') do { out += s(i); i += 1 }
+        if i+2 < n then { out ++= "\"\"\""; i += 3 } else while i < n do { out += s(i); i += 1 }
+      else if c == '"' then { flush(); copyDelim('"') }
+      else if c == '\'' then { flush(); copyDelim('\'') }
+      else { code += c; i += 1 }
+    flush()
+    out.toString
+  def touches(span: String): Boolean =
+    tok.findAllIn(span).exists(id.contains) || str.exists((sv, _) => span.contains(sv))

--- a/autotranslate/Main.scala
+++ b/autotranslate/Main.scala
@@ -350,8 +350,15 @@ object Main:
           if f.ext == "cls" then
             os.write.over(target, os.read(f).replace("\\usepackage[swedish]{babel}", "\\usepackage[english]{babel}"))
           else if doTranslate && (f.ext == "scala" || f.ext == "java") then
-            // Option B: translate comments + Swedish string literals; keep all code (identifiers) verbatim.
-            os.write.over(target, Code.translate(os.read(f), Translate.translatePlain))
+            // Option B + Option-D: rename Swedish identifiers via the shared CodeGlossary (so
+            // \scalainputlisting'd example programs read English in compendium-en/slides-en — the inline
+            // \ifswedish clamps can't reach external .scala files), then translate comments + Swedish string
+            // literals with Code.translate. Use renderCodeIds (identifiers in CODE regions only): strings +
+            // comments are left verbatim for Code.translate + Overrides, so a corpus-wide `str` replace can't
+            // half-translate them and knowledge strings ("Skållas."->"Blanched.") resolve via Overrides on
+            // their natural Swedish.
+            os.write.over(target, Code.translate(CodeGlossary.renderCodeIds(os.read(f)), Translate.translatePlain,
+              alsoTranslate = Translate.overrides.contains))
           else os.copy.over(f, target)
           nAsset += 1
       println(s"autotranslate: $src -> $dst  ($nTex .tex [$nTrans translated], $nAsset assets copied)")

--- a/autotranslate/Overrides.scala
+++ b/autotranslate/Overrides.scala
@@ -33,6 +33,12 @@ object Overrides:
 
   val overridingTranslations: Map[Swedish, English] = Map(
     // ── week 1: standalone concept words the model mistranslated ────────────────────────────
+    // vego example-file strings the model gets wrong (moved from CodeGlossary.str per #943 review): whole-unit
+    // match via Code.translate/translatePlain — no substring misfire. Keys are the trimmed string content.
+    "Skållas."                     -> "Blanched.",             // skålla = blanch, NOT scald
+    "Skalas med skalare."          -> "Peeled with a peeler.", // skalare = peeler, NOT scaler
+    "Antal skördade grönsaker:"    -> "Number of harvested vegetables:",
+    "Antal ätvärda grönsaker:"     -> "Number of vegetables worth eating:",
     "alternativ"          -> "selection",
     "repetition"          -> "repetition",
     "identifierare"       -> "identifier",

--- a/autotranslate/scratch/apply-b0d.scala
+++ b/autotranslate/scratch/apply-b0d.scala
@@ -3,6 +3,7 @@
 //> using dep com.lihaoyi::os-lib:0.11.8
 //> using file ../Latex.scala
 //> using file ../Code.scala
+//> using file ../CodeGlossary.scala
 
 // Fused B0+D applier (case (a): inline \code + verbatim code ENVS in .tex). For each code unit, compute the
 // English via a ratified cluster glossary (identifier rename + string/comment replace), and clamp it as
@@ -14,93 +15,8 @@
 
 import scala.util.matching.Regex
 
-object Glossary:
-  // VEGO cluster — ratified 2026-06-30 (vegomatch.scala + vego1-4 + w06-patterns), compile-verified.
-  // whole-identifier rename (token-exact). longest keys are fine; token replace is exact-match, not substring.
-  val id: Map[String, String] = Map(
-    "Grönsak" -> "Vegetable", "grönsak" -> "vegetable", "Grönsaker" -> "Vegetables", "grönsaker" -> "vegetables",
-    "Gurka" -> "Cucumber", "gurka" -> "cucumber", "ingenGurka" -> "noCucumber",
-    "Tomat" -> "Tomato", "tomat" -> "tomato",
-    "vikt" -> "weight", "ärRutten" -> "isRotten", "rutten" -> "rotten",
-    "slumpvikt" -> "randomWeight", "slumprutten" -> "randomRotten",
-    "slumpgurka" -> "randomCucumber", "slumptomat" -> "randomTomato", "slumpgrönsak" -> "randomVegetable",
-    "slumpbroccoli" -> "randomBroccoli", // exercise variant (w06): Broccoli stays (English), slump-prefix -> random
-    "Broccoli" -> "Broccoli", // identity: keep, but listed so a half-Swedish 'slumpbroccoli' can't slip the gate
-    "ärÄtvärd" -> "isWorthEating", "skörd" -> "harvest", "ätvärda" -> "worthEating", "ärÄtbar" -> "isEdible",
-    "anonymGrönsak" -> "anonymousVegetable",
-    "skalningsmetod" -> "peelingMethod", "skalfaktor" -> "peelFactor", "ärSkalad" -> "isPeeled", "skala" -> "peel",
-    // VEGO plural inflections used as val-names in REPL examples (lect-w10-extends).
-    "gurkor" -> "cucumbers", "vikter" -> "weights",
-    // GENERIC OO example (lect-w10-extends) — placeholder type names in the arv/subtyp illustration:
-    // `trait Bastyp` with `class Subtyp1/Subtyp2`. NOT a domain cluster; distinct from the prose words
-    // "bastyp"/"subtyp" (concepts, translated as prose). render() only touches code spans, so these
-    // rename the CODE identifiers only, never the prose term.
-    "Bastyp" -> "BaseType", "Subtyp1" -> "Subtype1", "Subtyp2" -> "Subtype2",
-    // lect-w10-extends demo identifiers (BR-ratified this session): encapsulation + inheritance examples.
-    // gEllerT = "Gurka eller Tomat" -> cOrT (Cucumber or Tomato); minHemlis/avslöjad = secret/reveal demo.
-    "gEllerT" -> "cOrT", "minHemlis" -> "mySecret", "vårHemlis" -> "ourSecret", "avslöjad" -> "revealed",
-    "pris" -> "price", "alternativ" -> "alternative", "StorGurkan" -> "BigCucumber",
-    // CARDS cluster (w06-patterns) — BR-RATIFIED 2026-06-30 (sameColourSuit + Färg->Suit confirmed).
-    // NOTE: Färg->Suit is CARDS-CONTEXT-ONLY; a kojo/colour file needs Färg->Colour (apply per-context).
-    "Färg" -> "Suit", "Kortlek" -> "Deck",
-    "Spader" -> "Spades", "Hjärter" -> "Hearts", "Ruter" -> "Diamonds", "Klöver" -> "Clubs",
-    // parafärg = short for parallellfärg = the same-COLOUR suit (Spades<->Clubs black, Hearts<->Diamonds red).
-    // No standard English card term exists (verified: bridge pairs suits by colour but has no single word),
-    // so use the clearest self-documenting name. NOT "partnerSuit" (collides with bridge 'partner' = player).
-    "parafärg" -> "sameColourSuit", "parallellFärg" -> "sameColourSuit",
-    // lect-w06-matching (pattern-matching lecture) identifiers — BR-ratified this session.
-    "smak" -> "taste", "lök" -> "onion", "testa" -> "test", "visa" -> "show", "svans" -> "tail",
-    "livetsMening" -> "meaningOfLife", "LivetsMening" -> "MeaningOfLife", "ärLivetsMening" -> "isMeaningOfLife",
-    "ärLivetsMeningBuggig" -> "isMeaningOfLifeBuggy", "ärLivetsMeningBackTicks" -> "isMeaningOfLifeBackTicks",
-    "svar" -> "answer", "värdeAttUndersöka" -> "valueToExamine",
-    "mönster1" -> "pattern1", "mönster2" -> "pattern2", "mönster3" -> "pattern3", "mönsterN" -> "patternN",
-    "resultat1" -> "result1", "resultat2" -> "result2", "resultat3" -> "result3", "resultatN" -> "resultN",
-  )
-  // string / comment inner text (longest first so a prefix doesn't pre-empt). exact substring replace.
-  val str: Seq[(String, String)] = Seq(
-    "Antal skördade grönsaker: " -> "Number of harvested vegetables: ",
-    "Antal ätvärda grönsaker:  " -> "Number of vegetables worth eating:  ",
-    "gurka är gott ibland..." -> "cucumber is tasty sometimes...",
-    "Skalas med skalare." -> "Peeled with a peeler.",
-    "Skållas." -> "Blanched.",  // BR: culinary term for peeling tomatoes (skålla = blanch), not "scald"
-    // lect-w10-extends output/string data (BR-ratified this session). Applied everywhere in a span, so they
-    // cover both the string literal and the REPL echo (e.g. `println(" Städa Städa")` + `... Städa Städa`).
-    "Det går precis lika bra med selleri!" -> "Celery works just as well!",
-    "kan kanske också funka med en betongpelare" -> "could maybe also work with a concrete pillar",
-    "Error: p är ej student; program saknas" -> "Error: p is not a student; program missing",
-    "Städa" -> "Clean", "Prata" -> "Talk", "hej" -> "hi",
-    // lect-w06-matching result/prompt strings — BR-ratified this session. `$`-interpolation fragments kept;
-    // sortBy(-length) ensures longer strings (e.g. "inte gott :(") replace before shorter ("gott").
-    "livets mening är funnen: " -> "the meaning of life is found: ",
-    "en rutten gurka som väger " -> "a rotten cucumber weighing ",
-    "exakt två grönsaker: " -> "exactly two vegetables: ",
-    "exakt en grönsak: " -> "exactly one vegetable: ",
-    " och sedan svansen: " -> " and then the tail: ",
-    "smakar bakvänt: " -> "tastes backwards: ",
-    "tom grönsaksvektor" -> "empty vegetable vector",
-    "okänd grönsak: " -> "unknown vegetable: ",
-    "fattas mening: " -> "missing meaning: ",
-    "Ange en grönsak" -> "Enter a vegetable",
-    "ganska gott..." -> "quite tasty...",
-    "mindre gott..." -> "less tasty...",
-    "gott ibland!" -> "tasty sometimes!",
-    "inte gott :(" -> "not tasty :(",
-    "gott, väger " -> "tasty, weighs ",
-    "först en " -> "first one ",
-    "jättegott!" -> "very tasty!",
-    "inte gott" -> "not tasty",
-    "gott!" -> "tasty!",
-    "inte " -> "not ",
-    " är " -> " is ",
-    "gott" -> "tasty",
-  ).sortBy(-_._1.length)
-
-  private val tok: Regex = "[A-Za-zÅÄÖåäö_][A-Za-z0-9ÅÄÖåäö_]*".r
-  def render(span: String): String =
-    val s1 = str.foldLeft(span) { case (acc, (sv, en)) => acc.replace(sv, en) } // strings first
-    tok.replaceAllIn(s1, m => Regex.quoteReplacement(id.getOrElse(m.matched, m.matched)))
-  def touches(span: String): Boolean =
-    tok.findAllIn(span).exists(id.contains) || str.exists((sv, _) => span.contains(sv))
+// glossary promoted to the production module autotranslate/CodeGlossary.scala (shared with the mirror).
+val Glossary = CodeGlossary
 
 // ALLOWLIST leak gate (BR-approved 2026-07-01). SOUND by construction: a clamped unit's English must contain
 // NO token that isn't recognized English / Scala / glossary. Anything unknown is treated as SUSPECT SWEDISH and


### PR DESCRIPTION
Translates Swedish identifiers in `\scalainputlisting`'d example programs (vego1-4.scala etc.) that leaked into the English compendium/slides chapter 10 (`object exempelVego1`, `trait Grönsak`, …). Single commit, rebased onto master.

## Root cause
Example programs are pulled via `\scalainputlisting`; the mirror translated them with `Code.translate` (comments + strings only, identifiers verbatim), and the inline `\ifswedish` clamps can't reach external `.scala` files.

## Change
- Promote the ratified apply-b0d glossary to a production module **`autotranslate/CodeGlossary.scala`** (single source of truth; apply-b0d aliases it).
- Mirror renames example `.scala`/`.java` identifiers via **`CodeGlossary.renderIds`** (token-exact identifiers only), then `Code.translate` handles comments + strings as before. `render` (id + str) is retained for the context-scoped slide clamps only.
- Add vego wrapper object names `exempelVego1..4 -> exampleVego1..4`.

## Verified
- `--verify-examples` COMPILE OK; mirror regenerates `compendium-en/examples/.../vego1.scala` as `object exampleVego1` / `trait Vegetable` / `class Cucumber(var weight)` / `isPeeled` — 0 model calls.

## Not covered (tracking #944)
`personExample*.scala` needs the PERSON cluster ratified (#942).