### PR TITLE
slides/lect-w10-override: Option-D clamps (MAYBE cluster + Färg colour hand-clamp)

### DIFF
--- a/autotranslate/scratch/apply-b0d.scala
+++ b/autotranslate/scratch/apply-b0d.scala
@@ -49,6 +49,8 @@ object Allow:
     // Scala stdlib + English words the dict misses, and all-lowercase LaTeX listing/font option keys
     // captured from code-env optional args (\begin{Code}[basicstyle=...\ttfamily\selectfont]) — never Swedish:
     "println", "instantiated", "basicstyle", "ttfamily", "selectfont", "numberstyle", "unapply",
+    "arity", // from Product.productArity (REPL tab-completion); "pepino" = a cucumber-variety fruit name
+    "pepino",
     // proper nouns kept verbatim in examples (BR): a personal-name demo, not a translatable identifier.
     "björn",
   )
@@ -162,7 +164,10 @@ object Apply:
     // slide goes mixed (define-English / diagram-Swedish). Treat it as dirtying the slide. NOT triggered by
     // bare prose Swedish (no code-display wrapper) -- that is translated downstream by the prose pass.
     def codeDisplaySwedish(s: String): Boolean =
-      Glossary.touches(s) &&
+      // an already-clamped \ifswedish...\else...\fi span is NOT un-clampable code-Swedish: its Swedish is in
+      // the protected \ifswedish branch and the \else is English (e.g. a hand-clamped colour `enum Färg`).
+      // Without this exclusion the Swedish glossary token in that branch's \code would falsely dirty the slide.
+      !s.trim.startsWith("\\ifswedish") && Glossary.touches(s) &&
         Seq("\\code", "\\jcode", "\\lstinline", "\\verb", "\\texttt").exists(s.contains)
     // a slide-group is dirty (un-clampable) if ANY candidate has residual suspects OR any non-candidate span
     // hides code-Swedish. A benign candidate (nothing to translate, no suspects) does NOT dirty the slide.

--- a/slides/body/lect-w10-override.tex
+++ b/slides/body/lect-w10-override.tex
@@ -115,6 +115,7 @@ Ovan fungerar fint eftersom vi nu har en giltig kombination av getter+setter.
 
 
 \begin{Slide}{Att skilja på mitt och ditt med \texttt{super}}
+\ifswedish
 \begin{REPL}
 scala> class X { def gurka = "super pepino" }
 
@@ -128,6 +129,21 @@ y: Y = Y@26ba2a48
 scala> y.gurka
 res0: String = :(
 \end{REPL}
+\else
+\begin{REPL}
+scala> class X { def cucumber = "super pepino" }
+
+scala> class Y extends X:
+         override val cucumber = ":("
+         val sg = super.cucumber
+
+scala> val y = new Y
+y: Y = Y@26ba2a48
+
+scala> y.cucumber
+res0: String = :(
+\end{REPL}
+\fi{}
 
 \pause
 Super Pepinos to the rescue:
@@ -233,15 +249,23 @@ Algebraisk datatyp \Eng{algebraic data type}, förk. ADT:
 \item En datatyp som består av (en kombination av): 
 \item \Emph{produkt}-typer och \Alert{summa}-typer:
 \begin{itemize}%\SlideFontTiny
-\item En produkt-typ är en ''och''-typ (ä.k. record, struct), exempel: \\ \code|case class Person(namn: String, ålder: Int)| \\består av attributen namn \Alert{OCH} ålder.
+\item En produkt-typ är en ''och''-typ (ä.k. record, struct), exempel: \\ \ifswedish\code|case class Person(namn: String, ålder: Int)|\else\code|case class Person(name: String, age: Int)|\fi{} \\består av attributen namn \Alert{OCH} ålder.
 \item En summa-typ  är en 'Eller''-typ (ä.k. disjunkt union, co-produkt).
-\item Exempel: \code|enum Färg { case Röd, Svart}| \\Färg kan vara antingen Röd \Emph{ELLER} Svart.
-\item[] En \code{Grönsak} är antingen en \code{Gurka} \Emph{ELLER} en \code{Tomat}
+\item Exempel: \ifswedish\code|enum Färg { case Röd, Svart}|\else\code|enum Colour { case Red, Black }|\fi{} \\Färg kan vara antingen Röd \Emph{ELLER} Svart.
+\item[] En \ifswedish\code{Grönsak}\else\code{Vegetable}\fi{} är antingen en \ifswedish\code{Gurka}\else\code{Cucumber}\fi{} \Emph{ELLER} en \ifswedish\code{Tomat}\else\code{Tomato}\fi{}
+\ifswedish
 \begin{Code}
 sealed trait Grönsak { val vikt: Int }
 case class Gurka(vikt: Int) extends Grönsak
 case class Tomat(vikt: Int) extends Grönsak
 \end{Code}
+\else
+\begin{Code}
+sealed trait Vegetable { val weight: Int }
+case class Cucumber(weight: Int) extends Vegetable
+case class Tomato(weight: Int) extends Vegetable
+\end{Code}
+\fi{}
 \end{itemize}  
 \end{itemize} 
 {\vspace{0.5em}\SlideFontTiny \url{https://en.wikipedia.org/wiki/Algebraic_data_type}}
@@ -249,6 +273,7 @@ case class Tomat(vikt: Int) extends Grönsak
 
 \begin{Slide}{En case-klass är en produkt.}
 Klassen \code{Person} nedan har ett namn \Alert{och} en ålder.
+\ifswedish
 \begin{REPL}
 scala> case class Person(namn: String, ålder: Int)
 
@@ -271,7 +296,32 @@ val res3: Int => Any = Lambda1981/0x00000008408f2840@44498af0
 scala> p.productElement(0)
 val res4: Any = Kim
 
-\end{REPL} 
+\end{REPL}
+\else
+\begin{REPL}
+scala> case class Person(name: String, age: Int)
+
+scala> val p = Person("Kim",42)
+val p: Person = Person(Kim,42)
+
+scala> p.isInstanceOf[Product]
+val res1: Boolean = true
+
+scala> p.product   // Tryck TAB
+productArity          productElement    productElementName
+productElementNames   productIterator   productPrefix
+          
+scala> p.productElementNames.toVector
+val res2: Vector[String] = Vector(name, age)
+
+scala> p.productElement
+val res3: Int => Any = Lambda1981/0x00000008408f2840@44498af0
+
+scala> p.productElement(0)
+val res4: Any = Kim
+
+\end{REPL}
+\fi{} 
 \end{Slide}
 
 
@@ -303,45 +353,96 @@ enum PersonalIdentity:
 
 \begin{Slide}{Algebraisk datatyp med typparameter}\SlideFontSmall
 \ifswedish Denna ADT har ett fall som är en \Emph{generisk} case-klass:\else This ADT has a case that is a \Emph{generic} case class:\fi     
+\ifswedish
 \begin{CodeSmall}
 sealed trait Kanske[+A]   // +A gör typen flexibel, ä.k. "kovariant" mer om det senare
 object Kanske:
   case class Någon[A](a: A) extends Kanske[A]
   case object Ingen extends Kanske[Nothing]   
 \end{CodeSmall}
+\else
+\begin{CodeSmall}
+sealed trait Maybe[+A]   // +A gör typen flexibel, ä.k. "kovariant" mer om det senare
+object Maybe:
+  case class Just[A](a: A) extends Maybe[A]
+  case object Empty extends Maybe[Nothing]   
+\end{CodeSmall}
+\fi{}
 \pause Motsvarande med \code{enum}: (kompilatorn fyller i \code{extends ...} automatiskt)
+\ifswedish
 \begin{CodeSmall}
 enum Kanske[+A]:
   case Någon(a: A)
   case Ingen     
 \end{CodeSmall}
+\else
+\begin{CodeSmall}
+enum Maybe[+A]:
+  case Just(a: A)
+  case Empty     
+\end{CodeSmall}
+\fi{}
 Känner du igen denna? \pause Jämför inbyggda typen \code{Option}\\~\\Övning: implementation av \code{getOrElse} med extensionsmetod
+\ifswedish
 \begin{CodeSmall}
 extension [A](k: Kanske[A]) def getOrElse(default: A):A = ??? 
    /* Tips: 
       använd match */
   
-\end{CodeSmall}     
+\end{CodeSmall}
+\else
+\begin{CodeSmall}
+extension [A](k: Maybe[A]) def getOrElse(default: A):A = ??? 
+   /* Tips: 
+      använd match */
+  
+\end{CodeSmall}
+\fi{}     
 \end{Slide}
 
 \begin{Slide}{Algebraisk datatyp med typparameter}\SlideFontSmall
 \ifswedish Denna ADT har ett fall som är en \Emph{generisk} case-klass:\else This ADT has a case that is a \Emph{generic} case class:\fi     
+\ifswedish
 \begin{CodeSmall}
 sealed trait Kanske[+A]   // +A gör typen flexibel, ä.k. "kovariant" mer om det senare
 object Kanske:
   case class Någon[A](a: A) extends Kanske[A]
   case object Ingen extends Kanske[Nothing]   
 \end{CodeSmall}
+\else
+\begin{CodeSmall}
+sealed trait Maybe[+A]   // +A gör typen flexibel, ä.k. "kovariant" mer om det senare
+object Maybe:
+  case class Just[A](a: A) extends Maybe[A]
+  case object Empty extends Maybe[Nothing]   
+\end{CodeSmall}
+\fi{}
 Motsvarande med \code{enum}: (kompilatorn fyller i \code{extends ...} automatiskt)
+\ifswedish
 \begin{CodeSmall}
 enum Kanske[+A]:
   case Någon(a: A)
   case Ingen     
 \end{CodeSmall}
+\else
+\begin{CodeSmall}
+enum Maybe[+A]:
+  case Just(a: A)
+  case Empty     
+\end{CodeSmall}
+\fi{}
 Känner du igen denna? Jämför inbyggda typen \code{Option}\\~\\Övning: implementation av \code{getOrElse} med extensionsmetod 
+\ifswedish
 \begin{CodeSmall}
 extension [A](k: Kanske[A]) def getOrElse(default: A):A = k match 
   case Kanske.Någon(a) => a
   case Kanske.Ingen => default
-\end{CodeSmall}     
+\end{CodeSmall}
+\else
+\begin{CodeSmall}
+extension [A](k: Maybe[A]) def getOrElse(default: A):A = k match 
+  case Maybe.Just(a) => a
+  case Maybe.Empty => default
+\end{CodeSmall}
+\fi{}     
 \end{Slide}


### PR DESCRIPTION
Clamps `lect-w10-override` to English, using the MAYBE + PERSON clusters ratified in #942.

> **Rebased onto `master`** (#945 merged): this PR is now independent, showing just its two commits — `64709dd5` (apply-b0d: don't let a hand-clamped `\ifswedish` span dirty its slide) and `258fd959` (slides/lect-w10-override: clamp code identifiers to English).

## What's here
- **13 code units clamped** (apply-b0d) via the MAYBE (`Kanske→Maybe`, `Någon→Just`, `Ingen→Empty`) and PERSON clusters.
- **Färg colour enum** — per-file HAND clamp: `enum Färg { case Röd, Svart }` → `enum Colour { case Red, Black }`. Per your #942 call, `Färg→Colour`/`Röd→Red`/`Svart→Black` stays OUT of the global glossary (which keeps `Färg→Suit` for cards); the Swedish enum is not renamed.
- **apply-b0d fix**: `codeDisplaySwedish` no longer treats an already-clamped `\ifswedish` span as un-clampable code-Swedish (it was falsely dirtying the colour-enum slide and suppressing its neighbours → a mixed slide). Also allowlists `arity` (`Product.productArity`) and `pepino` (fruit-name string value).

## Verified
- Slide-level gating: 11 slides → 4 fully-English, **0 mixed**.
- Rebuilt `slides-en/lect-w10-en.pdf` model-free (0 model calls): **4.6% Swedish** (was 8.8%). `enum Maybe/Just/Empty`, `enum Colour/Red/Black`, `Person(name/age)`, `Academic`, `Researcher` all render English; no `Suit` leak into the colour enum.

Not covered: `Examinerad` (personExample3) awaits your ratification call on #942.
