### PR TITLE
autotranslate: translate inline .tex code identifiers via CodeGlossary (#947)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,24 @@ on:
   push:
     branches:
       - main
+  pull_request:
   workflow_dispatch:
 
 jobs:
+  # "Only compilable code should pass": every example .scala the mirror translates via CodeGlossary must
+  # still compile after the identifier rename (catches e.g. an s-interpolation left pointing at a renamed
+  # field). Runs from source (renders on the fly) — no mirror/texlive needed, so it's a fast, standalone gate.
+  Example-compile-gate:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Setup scala-cli
+        uses: VirtusLab/scala-cli-setup@v1
+      - name: Compile gate for mirror example translation
+        run: scala-cli run autotranslate/scratch/verify-mirror-examples.scala -- .
+        shell: bash
+
   Compile-and-Build:
     strategy:
       matrix:

--- a/autotranslate/CodeGlossary.scala
+++ b/autotranslate/CodeGlossary.scala
@@ -111,10 +111,34 @@ object CodeGlossary:
   def renderCodeIds(s: String): String =
     val out = new StringBuilder; val code = new StringBuilder; var i = 0; val n = s.length
     def flush(): Unit = if code.nonEmpty then { out ++= renameAll(code.toString); code.clear() }
-    def copyDelim(q: Char): Unit = // copy a "..." or '...' literal verbatim (handles \-escapes)
+    def copyChar(): Unit = // copy a '...' char literal verbatim (handles \-escapes); never interpolated
       out += s(i); i += 1
-      while i < n && s(i) != q do { if s(i)=='\\' && i+1 < n then { out += s(i); i += 1 }; if i < n then { out += s(i); i += 1 } }
+      while i < n && s(i) != '\'' do { if s(i)=='\\' && i+1 < n then { out += s(i); i += 1 }; if i < n then { out += s(i); i += 1 } }
       if i < n then { out += s(i); i += 1 }
+    // an interpolator prefix (s"…"/f"…"/raw"…") is any identifier char immediately before the opening quote.
+    def isInterp: Boolean = out.nonEmpty && (out.last.isLetterOrDigit || out.last == '_')
+    // copy a "…" or \"\"\"…\"\"\" literal. Inside an s/f-interpolator, RENAME identifiers in ${…} and $ident
+    // — they are CODE references, and leaving them Swedish breaks compilation (e.g. s"${p.namn}" after
+    // namn->name -> "value namn is not a member"). Plain text stays verbatim; non-interpolated strings
+    // are copied byte-for-byte.
+    def copyStr(triple: Boolean, interp: Boolean): Unit =
+      if triple then { out ++= "\"\"\""; i += 3 } else { out += '"'; i += 1 }
+      def atClose: Boolean = if triple then i+2 < n && s(i)=='"' && s(i+1)=='"' && s(i+2)=='"' else i < n && s(i)=='"'
+      while i < n && !atClose do
+        val c = s(i)
+        if !triple && c == '\\' && i+1 < n then { out += c; i += 1; if i < n then { out += s(i); i += 1 } }
+        else if interp && c == '$' && i+1 < n && s(i+1) == '$' then { out ++= "$$"; i += 2 } // escaped literal $
+        else if interp && c == '$' && i+1 < n && s(i+1) == '{' then
+          out ++= "${"; i += 2; val st = i; var d = 1
+          while i < n && d > 0 do { val ch = s(i); if ch=='{' then d += 1 else if ch=='}' then d -= 1; if d > 0 then i += 1 }
+          out ++= renameAll(s.substring(st, i)); if i < n then { out += '}'; i += 1 }
+        else if interp && c == '$' && i+1 < n && (s(i+1).isLetter || s(i+1)=='_') then
+          out += '$'; i += 1; val st = i
+          while i < n && (s(i).isLetterOrDigit || s(i)=='_') do i += 1
+          out ++= renameAll(s.substring(st, i))
+        else { out += c; i += 1 }
+      if triple then { if i+2 < n then { out ++= "\"\"\""; i += 3 } else while i < n do { out += s(i); i += 1 } }
+      else if i < n then { out += '"'; i += 1 }
     while i < n do
       val c = s(i)
       if c == '/' && i+1 < n && s(i+1) == '/' then { flush(); while i < n && s(i) != '\n' do { out += s(i); i += 1 } }
@@ -122,12 +146,9 @@ object CodeGlossary:
         flush(); out ++= "/*"; i += 2
         while i+1 < n && !(s(i)=='*'&&s(i+1)=='/') do { out += s(i); i += 1 }
         if i+1 < n then { out ++= "*/"; i += 2 } else while i < n do { out += s(i); i += 1 }
-      else if c == '"' && i+2 < n && s(i+1)=='"' && s(i+2)=='"' then
-        flush(); out ++= "\"\"\""; i += 3
-        while i+2 < n && !(s(i)=='"'&&s(i+1)=='"'&&s(i+2)=='"') do { out += s(i); i += 1 }
-        if i+2 < n then { out ++= "\"\"\""; i += 3 } else while i < n do { out += s(i); i += 1 }
-      else if c == '"' then { flush(); copyDelim('"') }
-      else if c == '\'' then { flush(); copyDelim('\'') }
+      else if c == '"' && i+2 < n && s(i+1)=='"' && s(i+2)=='"' then { flush(); copyStr(true, isInterp) }
+      else if c == '"' then { flush(); copyStr(false, isInterp) }
+      else if c == '\'' then { flush(); copyChar() }
       else { code += c; i += 1 }
     flush()
     out.toString

--- a/autotranslate/CodeGlossary.scala
+++ b/autotranslate/CodeGlossary.scala
@@ -54,6 +54,12 @@ object CodeGlossary:
     "Examinerad" -> "Graduated",                                       // trait Graduated { val title: String }
     "kastaTärningTillsAllaUtfallUtomEtt" -> "rollDieUntilAllOutcomesExceptOne",
     "BaklängesHandler" -> "BackwardsHandler",
+    // ANIMAL cluster (w10-inheritance-exercise Task 3, `trait Djur`) — BR-agreed 2026-07-20.
+    // Inline .tex code (REPL/Code envs + prose \code{}) → translated by the mirror's inline pass (#948).
+    // The onomatopoeia string literals (Muuuuuuu/Nöffnöff/Gnääääägg) are English sounds too — via `codeStr`
+    // (whole-literal match applied inside string literals by renderCodeIds), NOT this id map.
+    "Djur" -> "Animal", "Ko" -> "Cow", "Gris" -> "Pig", "Häst" -> "Horse",
+    "väsnas" -> "makeNoise", "skapaDjur" -> "createAnimal", "bondgård" -> "farm",
   )
   // string / comment inner text (longest first so a prefix doesn't pre-empt). exact substring replace.
   val str: Seq[(String, String)] = Seq(
@@ -93,6 +99,16 @@ object CodeGlossary:
     "gott" -> "tasty",
   ).sortBy(-_._1.length)
 
+  // WHOLE-literal code-string translations, applied by renderCodeIds INSIDE string literals (both the mirror's
+  // inline-.tex pass and example .scala go through renderCodeIds). EXACT full-content match only — never a
+  // substring — so nothing half-translates (the failure mode that keeps `str` out of renderCodeIds). Use for
+  // ratified string DATA that must be English but isn't reachable via Code.translate/Overrides (inline .tex
+  // code never runs Code.translate). Keyed on the literal's inner text (no quotes).
+  val codeStr: Map[String, String] = Map(
+    // ANIMAL cluster onomatopoeia (w10-inheritance-exercise Task 3) — BR-ratified 2026-07-20: English sounds.
+    "Muuuuuuu" -> "Mooooo", "Nöffnöff" -> "Oink", "Gnääääägg" -> "Neigh",
+  )
+
   private val tok: Regex = "[A-Za-zÅÄÖåäö_][A-Za-z0-9ÅÄÖåäö_]*".r
   // `extra` (a per-file override map) wins over the global id, so a file with a context conflict can deviate.
   private def renameAll(span: String, extra: Map[String, String]): String =
@@ -105,10 +121,11 @@ object CodeGlossary:
   def render(span: String): String =
     renameAll(str.foldLeft(span) { case (acc, (sv, en)) => acc.replace(sv, en) }, Map.empty)
 
-  /** Token-exact IDENTIFIER rename applied ONLY in code regions; string/char literals and //, /* */ comments
-    * are copied VERBATIM. For mirrored example .scala/.java: identifiers get renamed, but strings/comments
-    * are left untouched so Code.translate + Overrides handle them on their natural Swedish (a knowledge
-    * string like "Skållas."->"Blanched." resolves via Overrides; nothing half-translates). No `str` here. */
+  /** Token-exact IDENTIFIER rename applied ONLY in code regions; //, /* */ comments and char literals are copied
+    * VERBATIM. String literals are copied verbatim TOO, except: a WHOLE-literal `codeStr` exact match is
+    * translated, and s/f-interpolation bodies get identifier renames. For mirrored example .scala/.java, other
+    * Swedish strings/comments are left for Code.translate + Overrides (a knowledge string like "Skållas."->
+    * "Blanched." resolves via Overrides; nothing half-translates). No bare-substring `str` replace here. */
   def renderCodeIds(s: String, extraId: Map[String, String] = Map.empty): String =
     val out = new StringBuilder; val code = new StringBuilder; var i = 0; val n = s.length
     def flush(): Unit = if code.nonEmpty then { out ++= renameAll(code.toString, extraId); code.clear() }
@@ -118,26 +135,38 @@ object CodeGlossary:
       if i < n then { out += s(i); i += 1 }
     // an interpolator prefix (s"…"/f"…"/raw"…") is any identifier char immediately before the opening quote.
     def isInterp: Boolean = out.nonEmpty && (out.last.isLetterOrDigit || out.last == '_')
-    // copy a "…" or \"\"\"…\"\"\" literal. Inside an s/f-interpolator, RENAME identifiers in ${…} and $ident
-    // — they are CODE references, and leaving them Swedish breaks compilation (e.g. s"${p.namn}" after
-    // namn->name -> "value namn is not a member"). Plain text stays verbatim; non-interpolated strings
-    // are copied byte-for-byte.
+    // rename identifiers inside an s/f-interpolator body (no quotes): ${…} and $ident are CODE references,
+    // renamed via renameAll; `$$` (escaped literal $) and plain text stay verbatim; `\x` escapes are copied
+    // as-is (so a `\$` never triggers interpolation).
+    def renameInterp(body: String): String =
+      val b = new StringBuilder; var j = 0; val m = body.length
+      while j < m do
+        val c = body(j)
+        if c == '\\' && j+1 < m then { b += c; j += 1; b += body(j); j += 1 }
+        else if c == '$' && j+1 < m && body(j+1) == '$' then { b ++= "$$"; j += 2 }
+        else if c == '$' && j+1 < m && body(j+1) == '{' then
+          b ++= "${"; j += 2; val st = j; var d = 1
+          while j < m && d > 0 do { val ch = body(j); if ch=='{' then d += 1 else if ch=='}' then d -= 1; if d > 0 then j += 1 }
+          b ++= renameAll(body.substring(st, j), extraId); if j < m then { b += '}'; j += 1 }
+        else if c == '$' && j+1 < m && (body(j+1).isLetter || body(j+1) == '_') then
+          b += '$'; j += 1; val st = j
+          while j < m && (body(j).isLetterOrDigit || body(j) == '_') do j += 1
+          b ++= renameAll(body.substring(st, j), extraId)
+        else { b += c; j += 1 }
+      b.toString
+    // copy a "…" or \"\"\"…\"\"\" literal. Precedence: (1) a WHOLE-literal `codeStr` exact match wins (ratified
+    // string DATA, e.g. the animal sounds); (2) inside an s/f-interpolator, RENAME identifiers in ${…}/$ident
+    // (leaving them Swedish breaks compilation, e.g. s"${p.namn}" after namn->name); (3) otherwise verbatim.
     def copyStr(triple: Boolean, interp: Boolean): Unit =
-      if triple then { out ++= "\"\"\""; i += 3 } else { out += '"'; i += 1 }
+      val open = if triple then "\"\"\"" else "\""
+      out ++= open; i += open.length
+      val start = i
       def atClose: Boolean = if triple then i+2 < n && s(i)=='"' && s(i+1)=='"' && s(i+2)=='"' else i < n && s(i)=='"'
-      while i < n && !atClose do
-        val c = s(i)
-        if !triple && c == '\\' && i+1 < n then { out += c; i += 1; if i < n then { out += s(i); i += 1 } }
-        else if interp && c == '$' && i+1 < n && s(i+1) == '$' then { out ++= "$$"; i += 2 } // escaped literal $
-        else if interp && c == '$' && i+1 < n && s(i+1) == '{' then
-          out ++= "${"; i += 2; val st = i; var d = 1
-          while i < n && d > 0 do { val ch = s(i); if ch=='{' then d += 1 else if ch=='}' then d -= 1; if d > 0 then i += 1 }
-          out ++= renameAll(s.substring(st, i), extraId); if i < n then { out += '}'; i += 1 }
-        else if interp && c == '$' && i+1 < n && (s(i+1).isLetter || s(i+1)=='_') then
-          out += '$'; i += 1; val st = i
-          while i < n && (s(i).isLetterOrDigit || s(i)=='_') do i += 1
-          out ++= renameAll(s.substring(st, i), extraId)
-        else { out += c; i += 1 }
+      while i < n && !atClose do { if !triple && s(i)=='\\' && i+1 < n then i += 2 else i += 1 }
+      val rawInner = s.substring(start, i)                 // literal content, verbatim (escapes preserved)
+      codeStr.get(rawInner) match
+        case Some(en) => out ++= en
+        case None     => out ++= (if interp then renameInterp(rawInner) else rawInner)
       if triple then { if i+2 < n then { out ++= "\"\"\""; i += 3 } else while i < n do { out += s(i); i += 1 } }
       else if i < n then { out += '"'; i += 1 }
     while i < n do

--- a/autotranslate/CodeGlossary.scala
+++ b/autotranslate/CodeGlossary.scala
@@ -94,23 +94,24 @@ object CodeGlossary:
   ).sortBy(-_._1.length)
 
   private val tok: Regex = "[A-Za-zÅÄÖåäö_][A-Za-z0-9ÅÄÖåäö_]*".r
-  private def renameAll(span: String): String =
-    tok.replaceAllIn(span, m => Regex.quoteReplacement(id.getOrElse(m.matched, m.matched)))
+  // `extra` (a per-file override map) wins over the global id, so a file with a context conflict can deviate.
+  private def renameAll(span: String, extra: Map[String, String]): String =
+    tok.replaceAllIn(span, m => Regex.quoteReplacement(extra.getOrElse(m.matched, id.getOrElse(m.matched, m.matched))))
 
   /** id rename + `str` replace over the WHOLE span (incl. inside string literals). CONTEXT-SCOPED: only for
     * the slide clamps (apply-b0d), where the `str` list is ratified per file. NOT for corpus-wide use —
     * `str` is a bare substring replace that half-translates partial-coverage strings and misfires on short
     * keys ("Städa toaletter" -> "Clean toaletter", "hej" in "hejsan"). */
   def render(span: String): String =
-    renameAll(str.foldLeft(span) { case (acc, (sv, en)) => acc.replace(sv, en) })
+    renameAll(str.foldLeft(span) { case (acc, (sv, en)) => acc.replace(sv, en) }, Map.empty)
 
   /** Token-exact IDENTIFIER rename applied ONLY in code regions; string/char literals and //, /* */ comments
     * are copied VERBATIM. For mirrored example .scala/.java: identifiers get renamed, but strings/comments
     * are left untouched so Code.translate + Overrides handle them on their natural Swedish (a knowledge
     * string like "Skållas."->"Blanched." resolves via Overrides; nothing half-translates). No `str` here. */
-  def renderCodeIds(s: String): String =
+  def renderCodeIds(s: String, extraId: Map[String, String] = Map.empty): String =
     val out = new StringBuilder; val code = new StringBuilder; var i = 0; val n = s.length
-    def flush(): Unit = if code.nonEmpty then { out ++= renameAll(code.toString); code.clear() }
+    def flush(): Unit = if code.nonEmpty then { out ++= renameAll(code.toString, extraId); code.clear() }
     def copyChar(): Unit = // copy a '...' char literal verbatim (handles \-escapes); never interpolated
       out += s(i); i += 1
       while i < n && s(i) != '\'' do { if s(i)=='\\' && i+1 < n then { out += s(i); i += 1 }; if i < n then { out += s(i); i += 1 } }
@@ -131,11 +132,11 @@ object CodeGlossary:
         else if interp && c == '$' && i+1 < n && s(i+1) == '{' then
           out ++= "${"; i += 2; val st = i; var d = 1
           while i < n && d > 0 do { val ch = s(i); if ch=='{' then d += 1 else if ch=='}' then d -= 1; if d > 0 then i += 1 }
-          out ++= renameAll(s.substring(st, i)); if i < n then { out += '}'; i += 1 }
+          out ++= renameAll(s.substring(st, i), extraId); if i < n then { out += '}'; i += 1 }
         else if interp && c == '$' && i+1 < n && (s(i+1).isLetter || s(i+1)=='_') then
           out += '$'; i += 1; val st = i
           while i < n && (s(i).isLetterOrDigit || s(i)=='_') do i += 1
-          out ++= renameAll(s.substring(st, i))
+          out ++= renameAll(s.substring(st, i), extraId)
         else { out += c; i += 1 }
       if triple then { if i+2 < n then { out ++= "\"\"\""; i += 3 } else while i < n do { out += s(i); i += 1 } }
       else if i < n then { out += '"'; i += 1 }
@@ -154,3 +155,18 @@ object CodeGlossary:
     out.toString
   def touches(span: String): Boolean =
     tok.findAllIn(span).exists(id.contains) || str.exists((sv, _) => span.contains(sv))
+
+  // ---- per-file deviations for the mirror's inline-.tex Scala-code pass (#944/#947) ----
+  // A mirror-relative path (e.g. "compendium/modules/w10-kojo-lab.tex") containing a key gets that map
+  // MERGED OVER the global id (override wins). Use for a context conflict — e.g. a colour enum where `Färg`
+  // must be `Colour` (not the global `Färg->Suit` for cards). Slide files with hand `\ifswedish` clamps
+  // need nothing here (their clamps are masked verbatim, so the mirror pass leaves them alone).
+  val perFileId: Map[String, Map[String, String]] = Map(
+    // e.g. "w01-kojo" -> Map("Färg" -> "Colour", "Röd" -> "Red", "Svart" -> "Black")
+  )
+  // Mirror-relative path substrings whose inline Scala-code envs SKIP the renderCodeIds pass entirely.
+  val optOut: Set[String] = Set()
+  /** Per-file override map for a mirror-relative path (empty = just the global id applies). */
+  def overridesFor(relPath: String): Map[String, String] =
+    perFileId.iterator.collect { case (k, m) if relPath.contains(k) => m }.flatten.toMap
+  def isOptedOut(relPath: String): Boolean = optOut.exists(relPath.contains)

--- a/autotranslate/Main.scala
+++ b/autotranslate/Main.scala
@@ -348,10 +348,12 @@ object Main:
           os.makeDir.all(target / os.up)
           val translate = doTranslate && selected(f)
           val body = os.read(f)
-          // HD2 hybrid: after prose translation, translate comments/strings inside inline code envs too
-          // (identifiers stay verbatim — the source-side \ifswedish id-glossary clamps handle those).
+          // HD2 hybrid: after prose translation, translate comments/strings inside inline code + code envs,
+          // AND rename Swedish identifiers in Scala-code envs / inline \code via the shared CodeGlossary
+          // (Option-D via the mirror — English-only, so the Swedish source stays byte-identical). `$src/$rel`
+          // is passed so CodeGlossary per-file overrides/opt-out (e.g. a colour Färg) can deviate.
           val outBody =
-            if translate then { nTrans += 1; Translate.translateCodeEnvBodies(Translate.translateTex(body, s"$src/$rel")) }
+            if translate then { nTrans += 1; Translate.translateCodeEnvBodies(Translate.translateTex(body, s"$src/$rel"), s"$src/$rel") }
             else body
           os.write.over(target, setEnglishFlags(enChrome(redirectListings(rewriteExternalDocs(rewriteInputs(outBody))))))
           nTex += 1

--- a/autotranslate/Translate.scala
+++ b/autotranslate/Translate.scala
@@ -643,11 +643,29 @@ object Translate:
     * (English-identifier) branch, completing that branch to fully-English code. This closes the gap where
     * inline code-env prose was translated by NEITHER the id-glossary NOR Code.translate (see the plan note).
     * Code envs do not nest, so a non-greedy DOTALL match to the matching `\end{env}` is exact. */
-  def translateCodeEnvBodies(tex: String): String =
+  // Scala-code envs whose identifiers are safe to rename via CodeGlossary. NOT all codeEnvs: tikz/pgf/forest
+  // (node NAMES / \foreach vars) and algorithm (keyword macros) would break refs/macros if renamed (see the
+  // Latex.verbatimEnvs notes). exlatex/envi (raw LaTeX examples), comment, verbatim/Verbatim also excluded.
+  private val scalaCodeEnvs = Set("Code", "CodeSmall", "REPL", "REPLnonum", "REPLsmall", "lstlisting", "Trace", "Output")
+  private val inlineCodeRe = raw"\\(code|jcode|lstinline)\{([^}]*)\}".r
+
+  /** After prose translation, translate the PROSE inside inline code + code ENVs (comments + Swedish strings,
+    * via Code.translate) AND — Option-D via the mirror — rename Swedish identifiers via CodeGlossary in the
+    * Scala-code envs and inline \code{}/\jcode{}/\lstinline{}. Identifier rename is ENGLISH-ONLY (the Swedish
+    * source is untouched, so no \ifswedish clamp is needed for it); it uses CodeGlossary.renderCodeIds
+    * (code-region-aware, id-only). `relPath` (mirror-relative) selects per-file overrides / opt-out
+    * (CodeGlossary.perFileId / optOut) so a context conflict (e.g. a colour `Färg`) can deviate. */
+  def translateCodeEnvBodies(tex: String, relPath: String = ""): String =
+    val extraId = CodeGlossary.overridesFor(relPath)
+    val doIds = !CodeGlossary.isOptedOut(relPath)
     val envAlt = codeEnvs.toSeq.map(java.util.regex.Pattern.quote).mkString("|")
     val re = ("(?s)(\\\\begin\\{(" + envAlt + ")\\})(.*?)(\\\\end\\{\\2\\})").r
-    re.replaceAllIn(tex, m =>
-      java.util.regex.Matcher.quoteReplacement(m.group(1) + Code.translate(m.group(3), translatePlain, skipTexComments = true) + m.group(4)))
+    val withEnvs = re.replaceAllIn(tex, m =>
+      val body = if doIds && scalaCodeEnvs(m.group(2)) then CodeGlossary.renderCodeIds(m.group(3), extraId) else m.group(3)
+      java.util.regex.Matcher.quoteReplacement(m.group(1) + Code.translate(body, translatePlain, skipTexComments = true) + m.group(4)))
+    if !doIds then withEnvs
+    else inlineCodeRe.replaceAllIn(withEnvs, m =>
+      java.util.regex.Matcher.quoteReplacement(s"\\${m.group(1)}{" + CodeGlossary.renderCodeIds(m.group(2), extraId) + "}"))
 
   // ---------- lifecycle ----------
   /** Load cache and make sure the model is ready (called before mirror translation).

--- a/autotranslate/scratch/verify-mirror-examples.scala
+++ b/autotranslate/scratch/verify-mirror-examples.scala
@@ -14,8 +14,13 @@
 // are SKIPPED (can't be gated in isolation; their definitions are gated via the files that DO stand alone).
 // Model-free: comments/strings don't affect compilation, so compiling renderCodeIds output is sufficient.
 //
+// Also a CONTENT LEAK-CHECK: every ratified code-STRING (CodeGlossary.codeStr, e.g. the animal-sound
+// onomatopoeia) must be translated wherever the mirror's inline-.tex pass runs renderCodeIds. A quoted Swedish
+// key surviving in a rendered Scala-code env / inline \code fails the gate — so a ratified sound can't regress
+// to Swedish, and a NEW sound added to a .tex but not to codeStr is caught.
+//
 //   scala-cli run autotranslate/scratch/verify-mirror-examples.scala -- <introprog-root>
-//   (exit 0 = clean, exit 1 = at least one regression)
+//   (exit 0 = clean, exit 1 = at least one regression or an untranslated ratified code-string)
 
 @main def verifyMirrorExamples(rootStr: String): Unit =
   val root = os.Path(rootStr, os.pwd)
@@ -39,7 +44,30 @@
         println(s"  REGRESSION: ${f.relativeTo(root)} — compiles in Swedish but NOT after rename")
       else skipped += 1                                     // not self-contained (imports/deps/@main) — not gatable here
   println(s"\n=== mirror example compile gate: $checked ok, $skipped skipped (not standalone), ${regressions.size} REGRESSIONS ===")
-  if regressions.nonEmpty then
-    println("FAIL — translation broke compilation in: " + regressions.mkString(", "))
-    sys.exit(1)
+  if regressions.nonEmpty then println("FAIL — translation broke compilation in: " + regressions.mkString(", "))
   else println("PASS — every rewritten, self-contained example still compiles.")
+
+  // ---- CONTENT LEAK-CHECK: ratified code-STRINGS (CodeGlossary.codeStr, e.g. the animal sounds) must actually
+  // be translated wherever the mirror's inline-.tex pass runs renderCodeIds. A quoted Swedish key surviving in a
+  // rendered Scala-code env or inline \code is an untranslated ratified string — fail. Mirrors Translate's
+  // scalaCodeEnvs + inlineCodeRe so it gates exactly what the mirror translates (this is why the sounds can't
+  // silently regress to Swedish; it also catches a NEW sound added to a .tex but not to codeStr).
+  val scalaCodeEnvs = Set("Code", "CodeSmall", "REPL", "REPLnonum", "REPLsmall", "lstlisting", "Trace", "Output")
+  val envRe = ("(?s)\\\\begin\\{(" + scalaCodeEnvs.mkString("|") + ")\\}(.*?)\\\\end\\{\\1\\}").r
+  val inlineRe = raw"\\(code|jcode|lstinline)\{([^}]*)\}".r
+  val texFiles = Seq("compendium", "slides").map(root / _).filter(os.exists)
+    .flatMap(d => os.walk(d)).filter(f => os.isFile(f) && f.ext == "tex").sortBy(_.toString)
+  val leaks = collection.mutable.ArrayBuffer[String]()
+  for f <- texFiles do
+    val tex = os.read(f)
+    def scan(body: String): Unit =
+      val en = CodeGlossary.renderCodeIds(body)
+      for k <- CodeGlossary.codeStr.keys if en.contains("\"" + k + "\"") do
+        leaks += s"""${f.relativeTo(root)}: ratified code-string "$k" left untranslated"""
+    for m <- envRe.findAllMatchIn(tex) do scan(m.group(2))
+    for m <- inlineRe.findAllMatchIn(tex) do scan(m.group(2))
+  println(s"\n=== inline .tex code-string leak-check: ${texFiles.size} .tex scanned, ${leaks.size} LEAKS ===")
+  if leaks.nonEmpty then leaks.foreach(l => println("  LEAK: " + l))
+  else println("PASS — every ratified code-string is translated in inline .tex code regions.")
+
+  if regressions.nonEmpty || leaks.nonEmpty then sys.exit(1)

--- a/autotranslate/scratch/verify-mirror-examples.scala
+++ b/autotranslate/scratch/verify-mirror-examples.scala
@@ -1,0 +1,45 @@
+//> using scala 3.8.4
+//> using jvm 21
+//> using dep com.lihaoyi::os-lib:0.11.8
+//> using file ../CodeGlossary.scala
+
+// COMPILE GATE for the mirror's example-code translation (#947/#948 + the personExample s-interp fix).
+// "Only compilable code should pass": every example .scala/.java that CodeGlossary.renderCodeIds rewrites
+// must still COMPILE after the identifier rename. For each CHANGED file we compile the rendered version
+// standalone; if it fails but the ORIGINAL compiled standalone, that's a translation-introduced REGRESSION
+// (e.g. an s-interpolation `s"${p.namn}"` left pointing at a renamed field) — the gate exits non-zero.
+//
+// Files that don't compile standalone on their own — cross-file imports (vego1Test imports exempelVego1),
+// external deps (shapes/SimpleDrawingWindow need a drawing lib), or a name that must match the filename —
+// are SKIPPED (can't be gated in isolation; their definitions are gated via the files that DO stand alone).
+// Model-free: comments/strings don't affect compilation, so compiling renderCodeIds output is sufficient.
+//
+//   scala-cli run autotranslate/scratch/verify-mirror-examples.scala -- <introprog-root>
+//   (exit 0 = clean, exit 1 = at least one regression)
+
+@main def verifyMirrorExamples(rootStr: String): Unit =
+  val root = os.Path(rootStr, os.pwd)
+  val dir = root / "compendium" / "examples"   // workspace/ is served by the hand-maintained workspace-en
+  val files = os.walk(dir).filter(f => os.isFile(f) && (f.ext == "scala" || f.ext == "java"))
+    .sortBy(_.toString)
+  def compiles(code: String, name: String): Boolean =
+    val tmp = os.temp.dir(prefix = "mirror-gate")          // keep the original filename (Java needs it)
+    os.write.over(tmp / name, code)
+    os.proc("scala-cli", "compile", "--server=false", (tmp / name).toString)
+      .call(check = false, mergeErrIntoOut = true).exitCode == 0
+  var checked = 0; var skipped = 0
+  val regressions = collection.mutable.ArrayBuffer[String]()
+  for f <- files do
+    val src = os.read(f)
+    val en = CodeGlossary.renderCodeIds(src)
+    if en != src then                                       // only rewritten files can regress
+      if compiles(en, f.last) then checked += 1
+      else if compiles(src, f.last) then
+        regressions += f.relativeTo(root).toString
+        println(s"  REGRESSION: ${f.relativeTo(root)} — compiles in Swedish but NOT after rename")
+      else skipped += 1                                     // not self-contained (imports/deps/@main) — not gatable here
+  println(s"\n=== mirror example compile gate: $checked ok, $skipped skipped (not standalone), ${regressions.size} REGRESSIONS ===")
+  if regressions.nonEmpty then
+    println("FAIL — translation broke compilation in: " + regressions.mkString(", "))
+    sys.exit(1)
+  else println("PASS — every rewritten, self-contained example still compiles.")


### PR DESCRIPTION
The systemic fix for #947: the mirror now translates identifiers in **inline `.tex` code** (both `\begin{Code}` envs and inline `\code{}`), not just external `\scalainputlisting` `.scala` files — using the single-source-of-truth `CodeGlossary`.

> **Rebased onto #950** (branch `option-d-compile-gate`). #948 modifies `renderCodeIds`, and so does #950's s-interpolation fix, so #948 now sits on top of #950 to inherit that fix and avoid a merge collision. Until #950 merges, this PR's diff-vs-`master` includes #950's 3 commits (s-interp fix + compile gate + CI); **merge #950 first**, then #948 rebases down to its own commits (inline-code + ANIMAL cluster + the leak-check).

## Mechanism (Option-D via the mirror — English-only, Swedish source untouched)
- `translateCodeEnvBodies` runs `CodeGlossary.renderCodeIds` on **Scala-code env** bodies (`Code`/`CodeSmall`/`REPL*`/`lstlisting`/`Trace`/`Output`) — **not** `tikzpicture`/`pgf`/`forest`/`algorithm`/`exlatex`/`envi`/`comment`/`verbatim` (renaming node names / macros there would break refs; restricted via `scalaCodeEnvs`).
- Also renders inline `\code{}`/`\jcode{}`/`\lstinline{}` in prose, so a listing and its surrounding `\code` stay consistent.
- **Per-file overrides / opt-out** via `CodeGlossary.perFileId` / `optOut` (keyed on the mirror-relative path Main passes), so a context conflict (e.g. a colour `Färg` needing `Colour` not the global `Suit`) can deviate. Empty for now — the only source `enum Färg` are w06 cards (`Suit`, correct); the w10 colour enum is a `\code|...|` hand-clamp untouched by the brace-only inline pass.

## Verified
- `w10-inheritance-exercise` Task 5 now renders English: `class Person(val name)` / `class Academic(...) extends Person(name)` / `Student` / `Researcher`, and the inline `\code{Academic}`/`\code{Researcher}` in the subtask prose.
- Full `compendium-en.pdf` rebuilt (0 model calls): **4.6% Swedish** (was 4.8%), **0 LaTeX errors** — no tikz/algorithm breakage.
- `IckeAkademiker` stays Swedish (not ratified — flagged on #942).
