### PR TITLE
autotranslate: fix half-translated concept-list terms (topptyp/bottentyp/inmixning supertyp)

### DIFF
--- a/autotranslate/Overrides.scala
+++ b/autotranslate/Overrides.scala
@@ -42,6 +42,11 @@ object Overrides:
     "alternativ"          -> "selection",
     "repetition"          -> "repetition",
     "identifierare"       -> "identifier",
+    // standalone concept-list items (\item topptyp / \item bottentyp in w10-chaphead): the model mangled these
+    // compound words into camelCase pseudo-identifiers ("topptype"/"bottomType"). The CONTEXTUAL rows already
+    // say "top type"/"bottom type"; override the standalone ones to match. (Cache rows purged.)
+    "topptyp"             -> "top type",
+    "bottentyp"           -> "bottom type",
     "slumptal"            -> "random number",
     "dod: operativsystem" -> "dod: operating system",
     "Denna kurs behandlar de tre första." -> "This course covers the first three.", // paradigms slide; model fallback kept Swedish

--- a/autotranslate/Overrides.scala
+++ b/autotranslate/Overrides.scala
@@ -42,11 +42,13 @@ object Overrides:
     "alternativ"          -> "selection",
     "repetition"          -> "repetition",
     "identifierare"       -> "identifier",
-    // standalone concept-list items (\item topptyp / \item bottentyp in w10-chaphead): the model mangled these
-    // compound words into camelCase pseudo-identifiers ("topptype"/"bottomType"). The CONTEXTUAL rows already
-    // say "top type"/"bottom type"; override the standalone ones to match. (Cache rows purged.)
+    // standalone concept-list items (\item topptyp / \item bottentyp / \item inmixning supertyp in w10-chaphead):
+    // the model mangled these compound words — "topptyp"/"bottentyp" into camelCase pseudo-identifiers
+    // ("topptype"/"bottomType"), and "inmixning supertyp" into a half-translated "mixin supertyp" (supertyp left
+    // Swedish, though the standalone "supertyp" row is "supertype"). Override to the correct terms. (Cache rows purged.)
     "topptyp"             -> "top type",
     "bottentyp"           -> "bottom type",
+    "inmixning supertyp"  -> "mixin supertype",
     "slumptal"            -> "random number",
     "dod: operativsystem" -> "dod: operating system",
     "Denna kurs behandlar de tre första." -> "This course covers the first three.", // paradigms slide; model fallback kept Swedish

--- a/autotranslate/translate-cache.tsv
+++ b/autotranslate/translate-cache.tsv
@@ -13279,7 +13279,6 @@ initierats	initialized
 initieringsfil:	initialization file:
 inkapsling	encapsulation
 inmixning	mixin
-inmixning supertyp	mixin supertyp
 innan	before
 innebär att initialiseringsuttrycket evalueras __C0__ gång, men evalueringen skjuts på framtiden tills det eventuellt händer att namnet __C1__ används, medan __C2__ innebär att funktionskroppens uttryck evalueras __C3__ namnet __C4__ (eventuellt) används.	This means that the initialization expression is evaluated __C0__ time, but the evaluation is postponed until the name __C1__ is possibly used, while __C2__ means that the function body's expression is evaluated __C3__ the name __C4__ (possibly) is used.
 innebär att initialiseringsuttrycket evalueras __C0____C1__en__C2__ gång, men evalueringen skjuts på framtiden tills det eventuellt händer att namnet __C3__ används, medan __C4__ innebär att funktionskroppens uttryck evalueras __C5____C6__varje gång__C7__ namnet __C8__ (eventuellt) används.	This means that the initialization expression is evaluated __C0__ __C1__once__C2__, but the evaluation is postponed until the name __C3__ is possibly used, while __C4__ means that the function body's expression is evaluated __C5__ __C6__every time__C7__ the name __C8__ (possibly) is used.

--- a/autotranslate/translate-cache.tsv
+++ b/autotranslate/translate-cache.tsv
@@ -12524,7 +12524,6 @@ boolean isString = x instanceof String;	boolean isString = x instanceof String;
 boolesk	boolean
 borttagna	removed
 borttagning	removal
-bottentyp	bottomType
 bra	good
 bra samarbete	good collaboration
 bra till det mesta	good for most things
@@ -14758,7 +14757,6 @@ tomma parentes-par	empty parentheses pair
 ton	a ton
 tonhöjd	pitch
 tonklass	class
-topptyp	topptype
 trait	trait
 trait Djur\ncase class Katt() extends Djur\ncase class Hund() extends Djur	trait Animal\ncase class Cat() extends Animal\ncase class Dog() extends Animal
 trait Fyle:\n  val läte: String\n  def väsnas: Unit = print(läte * 2)\n  val ärSimkunnig: Boolean\n  val ärFlygkunnig: Boolean	trait Fly:\n  val noise: String\n  def behaves: Unit = print(noise * 2)\n  val isWaterproof: Boolean\n  val isFlightCapable: Boolean


### PR DESCRIPTION
**Please ratify the wording.** In the **Concepts list of chapter 10** (`\item topptyp` / `\item bottentyp` in `w10-chaphead`), the terms render as **`topptype`** and **`bottomType`** — camelCase.

**Why camelCase?** The model mistranslated these standalone compound concept-words (`topptyp`, `bottentyp`) as if they were code identifiers → camelCase pseudo-identifiers. The *contextual* occurrences (inside sentences, e.g. "…nästan lika generell som topptypen Any") already translate correctly to **`top type`** / **`bottom type`** (existing cache rows).

**Fix:** override the two standalone units to match the contextual wording, and purge the two wrong cache rows:
- `topptyp` → `top type` (was `topptype`)
- `bottentyp` → `bottom type` (was `bottomType`)

Verified: the w10 concept list now renders `\item top type` / `\item bottom type`, 0 model calls. If you'd prefer different English (e.g. keep a one-word form), say so and I'll adjust — hence asking you to ratify.


---

**Also (same failure class): `inmixning supertyp` → `mixin supertype`.**
The concept-list item `\item inmixning supertyp` rendered the half-translated **`mixin supertyp`** — the model translated `inmixning`→`mixin` but left `supertyp` Swedish, even though the standalone `supertyp` cache row is already `supertype`.

**Fix:** override `inmixning supertyp` → `mixin supertype` and purge the wrong cache row (`inmixning supertyp` ⇒ `mixin supertyp`). Verified: the w10 concept list now renders `\item mixin supertype`, 0 model calls.