### PR TITLE
autotranslate: fix s-interpolation example-compile break + CI compile gate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,24 @@ on:
   push:
     branches:
       - main
+  pull_request:
   workflow_dispatch:
 
 jobs:
+  # "Only compilable code should pass": every example .scala the mirror translates via CodeGlossary must
+  # still compile after the identifier rename (catches e.g. an s-interpolation left pointing at a renamed
+  # field). Runs from source (renders on the fly) — no mirror/texlive needed, so it's a fast, standalone gate.
+  Example-compile-gate:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Setup scala-cli
+        uses: VirtusLab/scala-cli-setup@v1
+      - name: Compile gate for mirror example translation
+        run: scala-cli run autotranslate/scratch/verify-mirror-examples.scala -- .
+        shell: bash
+
   Compile-and-Build:
     strategy:
       matrix:

--- a/autotranslate/CodeGlossary.scala
+++ b/autotranslate/CodeGlossary.scala
@@ -111,10 +111,34 @@ object CodeGlossary:
   def renderCodeIds(s: String): String =
     val out = new StringBuilder; val code = new StringBuilder; var i = 0; val n = s.length
     def flush(): Unit = if code.nonEmpty then { out ++= renameAll(code.toString); code.clear() }
-    def copyDelim(q: Char): Unit = // copy a "..." or '...' literal verbatim (handles \-escapes)
+    def copyChar(): Unit = // copy a '...' char literal verbatim (handles \-escapes); never interpolated
       out += s(i); i += 1
-      while i < n && s(i) != q do { if s(i)=='\\' && i+1 < n then { out += s(i); i += 1 }; if i < n then { out += s(i); i += 1 } }
+      while i < n && s(i) != '\'' do { if s(i)=='\\' && i+1 < n then { out += s(i); i += 1 }; if i < n then { out += s(i); i += 1 } }
       if i < n then { out += s(i); i += 1 }
+    // an interpolator prefix (s"…"/f"…"/raw"…") is any identifier char immediately before the opening quote.
+    def isInterp: Boolean = out.nonEmpty && (out.last.isLetterOrDigit || out.last == '_')
+    // copy a "…" or \"\"\"…\"\"\" literal. Inside an s/f-interpolator, RENAME identifiers in ${…} and $ident
+    // — they are CODE references, and leaving them Swedish breaks compilation (e.g. s"${p.namn}" after
+    // namn->name -> "value namn is not a member"). Plain text stays verbatim; non-interpolated strings
+    // are copied byte-for-byte.
+    def copyStr(triple: Boolean, interp: Boolean): Unit =
+      if triple then { out ++= "\"\"\""; i += 3 } else { out += '"'; i += 1 }
+      def atClose: Boolean = if triple then i+2 < n && s(i)=='"' && s(i+1)=='"' && s(i+2)=='"' else i < n && s(i)=='"'
+      while i < n && !atClose do
+        val c = s(i)
+        if !triple && c == '\\' && i+1 < n then { out += c; i += 1; if i < n then { out += s(i); i += 1 } }
+        else if interp && c == '$' && i+1 < n && s(i+1) == '$' then { out ++= "$$"; i += 2 } // escaped literal $
+        else if interp && c == '$' && i+1 < n && s(i+1) == '{' then
+          out ++= "${"; i += 2; val st = i; var d = 1
+          while i < n && d > 0 do { val ch = s(i); if ch=='{' then d += 1 else if ch=='}' then d -= 1; if d > 0 then i += 1 }
+          out ++= renameAll(s.substring(st, i)); if i < n then { out += '}'; i += 1 }
+        else if interp && c == '$' && i+1 < n && (s(i+1).isLetter || s(i+1)=='_') then
+          out += '$'; i += 1; val st = i
+          while i < n && (s(i).isLetterOrDigit || s(i)=='_') do i += 1
+          out ++= renameAll(s.substring(st, i))
+        else { out += c; i += 1 }
+      if triple then { if i+2 < n then { out ++= "\"\"\""; i += 3 } else while i < n do { out += s(i); i += 1 } }
+      else if i < n then { out += '"'; i += 1 }
     while i < n do
       val c = s(i)
       if c == '/' && i+1 < n && s(i+1) == '/' then { flush(); while i < n && s(i) != '\n' do { out += s(i); i += 1 } }
@@ -122,12 +146,9 @@ object CodeGlossary:
         flush(); out ++= "/*"; i += 2
         while i+1 < n && !(s(i)=='*'&&s(i+1)=='/') do { out += s(i); i += 1 }
         if i+1 < n then { out ++= "*/"; i += 2 } else while i < n do { out += s(i); i += 1 }
-      else if c == '"' && i+2 < n && s(i+1)=='"' && s(i+2)=='"' then
-        flush(); out ++= "\"\"\""; i += 3
-        while i+2 < n && !(s(i)=='"'&&s(i+1)=='"'&&s(i+2)=='"') do { out += s(i); i += 1 }
-        if i+2 < n then { out ++= "\"\"\""; i += 3 } else while i < n do { out += s(i); i += 1 }
-      else if c == '"' then { flush(); copyDelim('"') }
-      else if c == '\'' then { flush(); copyDelim('\'') }
+      else if c == '"' && i+2 < n && s(i+1)=='"' && s(i+2)=='"' then { flush(); copyStr(true, isInterp) }
+      else if c == '"' then { flush(); copyStr(false, isInterp) }
+      else if c == '\'' then { flush(); copyChar() }
       else { code += c; i += 1 }
     flush()
     out.toString

--- a/autotranslate/scratch/verify-mirror-examples.scala
+++ b/autotranslate/scratch/verify-mirror-examples.scala
@@ -1,0 +1,45 @@
+//> using scala 3.8.4
+//> using jvm 21
+//> using dep com.lihaoyi::os-lib:0.11.8
+//> using file ../CodeGlossary.scala
+
+// COMPILE GATE for the mirror's example-code translation (#947/#948 + the personExample s-interp fix).
+// "Only compilable code should pass": every example .scala/.java that CodeGlossary.renderCodeIds rewrites
+// must still COMPILE after the identifier rename. For each CHANGED file we compile the rendered version
+// standalone; if it fails but the ORIGINAL compiled standalone, that's a translation-introduced REGRESSION
+// (e.g. an s-interpolation `s"${p.namn}"` left pointing at a renamed field) — the gate exits non-zero.
+//
+// Files that don't compile standalone on their own — cross-file imports (vego1Test imports exempelVego1),
+// external deps (shapes/SimpleDrawingWindow need a drawing lib), or a name that must match the filename —
+// are SKIPPED (can't be gated in isolation; their definitions are gated via the files that DO stand alone).
+// Model-free: comments/strings don't affect compilation, so compiling renderCodeIds output is sufficient.
+//
+//   scala-cli run autotranslate/scratch/verify-mirror-examples.scala -- <introprog-root>
+//   (exit 0 = clean, exit 1 = at least one regression)
+
+@main def verifyMirrorExamples(rootStr: String): Unit =
+  val root = os.Path(rootStr, os.pwd)
+  val dir = root / "compendium" / "examples"   // workspace/ is served by the hand-maintained workspace-en
+  val files = os.walk(dir).filter(f => os.isFile(f) && (f.ext == "scala" || f.ext == "java"))
+    .sortBy(_.toString)
+  def compiles(code: String, name: String): Boolean =
+    val tmp = os.temp.dir(prefix = "mirror-gate")          // keep the original filename (Java needs it)
+    os.write.over(tmp / name, code)
+    os.proc("scala-cli", "compile", "--server=false", (tmp / name).toString)
+      .call(check = false, mergeErrIntoOut = true).exitCode == 0
+  var checked = 0; var skipped = 0
+  val regressions = collection.mutable.ArrayBuffer[String]()
+  for f <- files do
+    val src = os.read(f)
+    val en = CodeGlossary.renderCodeIds(src)
+    if en != src then                                       // only rewritten files can regress
+      if compiles(en, f.last) then checked += 1
+      else if compiles(src, f.last) then
+        regressions += f.relativeTo(root).toString
+        println(s"  REGRESSION: ${f.relativeTo(root)} — compiles in Swedish but NOT after rename")
+      else skipped += 1                                     // not self-contained (imports/deps/@main) — not gatable here
+  println(s"\n=== mirror example compile gate: $checked ok, $skipped skipped (not standalone), ${regressions.size} REGRESSIONS ===")
+  if regressions.nonEmpty then
+    println("FAIL — translation broke compilation in: " + regressions.mkString(", "))
+    sys.exit(1)
+  else println("PASS — every rewritten, self-contained example still compiles.")


### PR DESCRIPTION
Fixes the compile regression you found (compendium-en **10.1.27:21 / 10.1.29:17**) and adds the compile gate you asked for.

## Bug
`CodeGlossary.renderCodeIds` is code-region-aware and copied string literals verbatim — but a Scala **s-interpolation** `${…}`/`$ident` is *code* referencing identifiers. After a field rename the interpolation still named the old field, so it didn't compile: `personExample1` `s"${kim.namn} …"` after `namn→name` → *"value namn is not a member"*.

## Fix
`renderCodeIds` now renames identifiers inside interpolations (when an identifier char precedes the quote — `s"…"`/`f"…"`/`raw"…"`); plain text and non-interpolated strings stay verbatim (`$$` and char literals handled). personExample1/2/3 now compile; line 21 → `s"${kim.name} ${kim.university} ${kim.program}"`.

## Gate (your ask — "only compilable code should pass")
- `autotranslate/scratch/verify-mirror-examples.scala` — renders every example `.scala/.java` via `CodeGlossary` and compiles it standalone; a rendered file that fails while the Swedish original compiled = a **regression** → exit 1. Non-self-contained files (cross-imports/deps/`@main` dups) are skipped. Current run: **10 ok, 2 skipped, 0 regressions**.
- **CI enforcement**: new `Example-compile-gate` job in `main.yml`, and CI now triggers on `pull_request` (was push-to-main only). The gate runs from source (no mirror/texlive) so it's fast.

## To make it blocking
Enable branch protection on `main` requiring the **Example-compile-gate** check — that's the repo setting that turns the check into a hard merge gate.