### PR TITLE
Option-D w10 follow-ups: scope ANIMAL, ratified terms, protect \ifswedish clamps

### DIFF
--- a/autotranslate/CodeGlossary.scala
+++ b/autotranslate/CodeGlossary.scala
@@ -49,17 +49,15 @@ object CodeGlossary:
     "Kanske" -> "Maybe", "Någon" -> "Just", "Ingen" -> "Empty",
     // PERSON cluster (personExample*.scala + lect-w10-override) — BR-ratified 2026-07-19 (#942).
     "namn" -> "name", "ålder" -> "age", "universitet" -> "university", "titel" -> "title",
-    "Akademiker" -> "Academic", "Forskare" -> "Researcher",
+    "Akademiker" -> "Academic", "Forskare" -> "Researcher", "IckeAkademiker" -> "NonAcademic",
     // one-off example identifiers surfaced by the #944 coverage sweep — BR-ratified 2026-07-19 (#942).
     "Examinerad" -> "Graduated",                                       // trait Graduated { val title: String }
     "kastaTärningTillsAllaUtfallUtomEtt" -> "rollDieUntilAllOutcomesExceptOne",
     "BaklängesHandler" -> "BackwardsHandler",
-    // ANIMAL cluster (w10-inheritance-exercise Task 3, `trait Djur`) — BR-agreed 2026-07-20.
-    // Inline .tex code (REPL/Code envs + prose \code{}) → translated by the mirror's inline pass (#948).
-    // The onomatopoeia string literals (Muuuuuuu/Nöffnöff/Gnääääägg) are English sounds too — via `codeStr`
-    // (whole-literal match applied inside string literals by renderCodeIds), NOT this id map.
-    "Djur" -> "Animal", "Ko" -> "Cow", "Gris" -> "Pig", "Häst" -> "Horse",
-    "väsnas" -> "makeNoise", "skapaDjur" -> "createAnimal", "bondgård" -> "farm",
+    // NB: the ANIMAL cluster (Djur/Ko/Gris/Häst/väsnas/skapaDjur/bondgård) is NOT global — it lives in
+    // `perFileId` scoped to w10-inheritance-exercise. `Djur` also occurs in lect-w11-context's generics demo
+    // (class Katt/Hund extends Djur) where Katt/Hund aren't in the glossary; a global Djur->Animal rendered
+    // `class Katt extends Animal` (mixed). Scoping keeps w11 fully Swedish until that lecture is translated.
   )
   // string / comment inner text (longest first so a prefix doesn't pre-empt). exact substring replace.
   val str: Seq[(String, String)] = Seq(
@@ -192,6 +190,14 @@ object CodeGlossary:
   // need nothing here (their clamps are masked verbatim, so the mirror pass leaves them alone).
   val perFileId: Map[String, Map[String, String]] = Map(
     // e.g. "w01-kojo" -> Map("Färg" -> "Colour", "Röd" -> "Red", "Svart" -> "Black")
+    // ANIMAL cluster — scoped here (NOT global) so `Djur` doesn't bleed into lect-w11-context's generics demo
+    // (class Katt/Hund extends Djur, where Katt/Hund aren't glossary'd -> mixed `class Katt extends Animal`).
+    // Task 3's own Fyle-bird example in this same file is hand-clamped (\ifswedish), so the mirror leaves it
+    // alone (Latex.ifswedishRanges); only Task 3's unclamped REPL/Code envs get these. BR-agreed 2026-07-20.
+    "w10-inheritance-exercise" -> Map(
+      "Djur" -> "Animal", "Ko" -> "Cow", "Gris" -> "Pig", "Häst" -> "Horse",
+      "väsnas" -> "makeNoise", "skapaDjur" -> "createAnimal", "bondgård" -> "farm",
+    ),
   )
   // Mirror-relative path substrings whose inline Scala-code envs SKIP the renderCodeIds pass entirely.
   val optOut: Set[String] = Set()

--- a/autotranslate/CodeGlossary.scala
+++ b/autotranslate/CodeGlossary.scala
@@ -50,6 +50,9 @@ object CodeGlossary:
     // PERSON cluster (personExample*.scala + lect-w10-override) — BR-ratified 2026-07-19 (#942).
     "namn" -> "name", "ålder" -> "age", "universitet" -> "university", "titel" -> "title",
     "Akademiker" -> "Academic", "Forskare" -> "Researcher", "IckeAkademiker" -> "NonAcademic",
+    // lowercase val-name forms (Task 5 REPL: `val akademiker = new Academic(...)`) — same words as the classes
+    // above, just lowercased per Scala val-naming convention — BR-ratified 2026-07-21.
+    "akademiker" -> "academic", "forskare" -> "researcher",
     // one-off example identifiers surfaced by the #944 coverage sweep — BR-ratified 2026-07-19 (#942).
     "Examinerad" -> "Graduated",                                       // trait Graduated { val title: String }
     "kastaTärningTillsAllaUtfallUtomEtt" -> "rollDieUntilAllOutcomesExceptOne",
@@ -105,6 +108,8 @@ object CodeGlossary:
   val codeStr: Map[String, String] = Map(
     // ANIMAL cluster onomatopoeia (w10-inheritance-exercise Task 3) — BR-ratified 2026-07-20: English sounds.
     "Muuuuuuu" -> "Mooooo", "Nöffnöff" -> "Oink", "Gnääääägg" -> "Neigh",
+    // PERSON: the researcher's title value (Task 5 REPL: new Researcher(..., "Doktorand")) — BR-ratified 2026-07-21.
+    "Doktorand" -> "PhD student",
   )
 
   private val tok: Regex = "[A-Za-zÅÄÖåäö_][A-Za-z0-9ÅÄÖåäö_]*".r

--- a/autotranslate/Latex.scala
+++ b/autotranslate/Latex.scala
@@ -141,6 +141,19 @@ object Latex:
       else i += 1
     i
 
+  /** Character ranges `[start, end)` of every top-level `\ifswedish...\fi` block (nesting-aware via matchFi).
+    * The mirror's code-env / inline-code translation uses this to LEAVE hand-clamped code alone: both branches
+    * of a `\ifswedish<sv>\else<en>\fi` clamp are already final, so translating inside one would mutate the
+    * Swedish branch (e.g. rename `väsnas`->`makeNoise` while its neighbours stay Swedish -> a mixed listing). */
+  def ifswedishRanges(s: String): Seq[(Int, Int)] =
+    val out = scala.collection.mutable.ArrayBuffer[(Int, Int)]()
+    val tag = "\\ifswedish"; var i = 0
+    while i >= 0 && i < s.length do
+      val k = s.indexOf(tag, i)
+      if k < 0 then i = -1
+      else { val end = matchFi(s, k + tag.length); out += ((k, end)); i = end }
+    out.toSeq
+
   /** Mask the source. Returns (maskedText, spans, itemIdx) where itemIdx is the set of placeholder
     * indices that are `\item` markers (used to split bullet lists into per-item translation units).
     * With stripEng=true, `\Eng{...}` is removed. */

--- a/autotranslate/Overrides.scala
+++ b/autotranslate/Overrides.scala
@@ -42,13 +42,14 @@ object Overrides:
     "alternativ"          -> "selection",
     "repetition"          -> "repetition",
     "identifierare"       -> "identifier",
-    // standalone concept-list items (\item topptyp / \item bottentyp / \item inmixning supertyp in w10-chaphead):
-    // the model mangled these compound words — "topptyp"/"bottentyp" into camelCase pseudo-identifiers
-    // ("topptype"/"bottomType"), and "inmixning supertyp" into a half-translated "mixin supertyp" (supertyp left
-    // Swedish, though the standalone "supertyp" row is "supertype"). Override to the correct terms. (Cache rows purged.)
+    // standalone concept-list items (\item topptyp / \item bottentyp in w10-chaphead): the model mangled these
+    // compound words into camelCase pseudo-identifiers ("topptype"/"bottomType"). The CONTEXTUAL rows already
+    // say "top type"/"bottom type"; override the standalone ones to match. (Wrong cache rows purged.)
+    // (The former `inmixning supertyp` -> `mixin supertype` override was dropped once BR fixed the missing comma
+    //  at plan/Plan.scala (53730d5, #952): that item is now two separate concepts, `inmixning`->mixin and
+    //  `supertyp`->supertype, each translating on its own via existing cache rows.)
     "topptyp"             -> "top type",
     "bottentyp"           -> "bottom type",
-    "inmixning supertyp"  -> "mixin supertype",
     "slumptal"            -> "random number",
     "dod: operativsystem" -> "dod: operating system",
     "Denna kurs behandlar de tre första." -> "This course covers the first three.", // paradigms slide; model fallback kept Swedish

--- a/autotranslate/Translate.scala
+++ b/autotranslate/Translate.scala
@@ -658,14 +658,27 @@ object Translate:
   def translateCodeEnvBodies(tex: String, relPath: String = ""): String =
     val extraId = CodeGlossary.overridesFor(relPath)
     val doIds = !CodeGlossary.isOptedOut(relPath)
+    // Leave code inside `\ifswedish...\fi` clamps alone: both branches are hand-final, so translating there
+    // would mutate the Swedish branch into a mixed listing (e.g. `def makeNoise` next to `print(läte*2)` in the
+    // hand-clamped Fyle example). Ranges computed on the ORIGINAL text; matches keep their original offsets
+    // because replaceAllIn scans left-to-right and we test m.start against the pre-substitution positions.
+    val protectedRanges = Latex.ifswedishRanges(tex)
+    def clamped(pos: Int): Boolean = protectedRanges.exists((a, b) => pos >= a && pos < b)
     val envAlt = codeEnvs.toSeq.map(java.util.regex.Pattern.quote).mkString("|")
     val re = ("(?s)(\\\\begin\\{(" + envAlt + ")\\})(.*?)(\\\\end\\{\\2\\})").r
     val withEnvs = re.replaceAllIn(tex, m =>
-      val body = if doIds && scalaCodeEnvs(m.group(2)) then CodeGlossary.renderCodeIds(m.group(3), extraId) else m.group(3)
-      java.util.regex.Matcher.quoteReplacement(m.group(1) + Code.translate(body, translatePlain, skipTexComments = true) + m.group(4)))
+      if clamped(m.start) then java.util.regex.Matcher.quoteReplacement(m.matched)
+      else
+        val body = if doIds && scalaCodeEnvs(m.group(2)) then CodeGlossary.renderCodeIds(m.group(3), extraId) else m.group(3)
+        java.util.regex.Matcher.quoteReplacement(m.group(1) + Code.translate(body, translatePlain, skipTexComments = true) + m.group(4)))
     if !doIds then withEnvs
-    else inlineCodeRe.replaceAllIn(withEnvs, m =>
-      java.util.regex.Matcher.quoteReplacement(s"\\${m.group(1)}{" + CodeGlossary.renderCodeIds(m.group(2), extraId) + "}"))
+    else
+      // the env pass changed lengths, so recompute clamp ranges against `withEnvs` for the inline pass.
+      val inlineRanges = Latex.ifswedishRanges(withEnvs)
+      def clampedInline(pos: Int): Boolean = inlineRanges.exists((a, b) => pos >= a && pos < b)
+      inlineCodeRe.replaceAllIn(withEnvs, m =>
+        if clampedInline(m.start) then java.util.regex.Matcher.quoteReplacement(m.matched)
+        else java.util.regex.Matcher.quoteReplacement(s"\\${m.group(1)}{" + CodeGlossary.renderCodeIds(m.group(2), extraId) + "}"))
 
   // ---------- lifecycle ----------
   /** Load cache and make sure the model is ready (called before mirror translation).

--- a/autotranslate/scratch/verify-mirror-examples.scala
+++ b/autotranslate/scratch/verify-mirror-examples.scala
@@ -2,6 +2,7 @@
 //> using jvm 21
 //> using dep com.lihaoyi::os-lib:0.11.8
 //> using file ../CodeGlossary.scala
+//> using file ../Latex.scala
 
 // COMPILE GATE for the mirror's example-code translation (#947/#948 + the personExample s-interp fix).
 // "Only compilable code should pass": every example .scala/.java that CodeGlossary.renderCodeIds rewrites
@@ -19,14 +20,19 @@
 // key surviving in a rendered Scala-code env / inline \code fails the gate — so a ratified sound can't regress
 // to Swedish, and a NEW sound added to a .tex but not to codeStr is caught.
 //
+// Plus a PHASE-1 INLINE .tex COMPILE GATE (#951): the same regression rule applied to the display Scala-code
+// envs (Code/CodeSmall/lstlisting) the mirror rewrites in .tex — skipping \ifswedish-clamped code and deferring
+// REPL transcripts to phase 2. See that section below.
+//
 //   scala-cli run autotranslate/scratch/verify-mirror-examples.scala -- <introprog-root>
 //   (exit 0 = clean, exit 1 = at least one regression or an untranslated ratified code-string)
 
 @main def verifyMirrorExamples(rootStr: String): Unit =
   val root = os.Path(rootStr, os.pwd)
   val dir = root / "compendium" / "examples"   // workspace/ is served by the hand-maintained workspace-en
-  val files = os.walk(dir).filter(f => os.isFile(f) && (f.ext == "scala" || f.ext == "java"))
-    .sortBy(_.toString)
+  val files =
+    if !os.exists(dir) then Seq.empty[os.Path]
+    else os.walk(dir).filter(f => os.isFile(f) && (f.ext == "scala" || f.ext == "java")).sortBy(_.toString)
   def compiles(code: String, name: String): Boolean =
     val tmp = os.temp.dir(prefix = "mirror-gate")          // keep the original filename (Java needs it)
     os.write.over(tmp / name, code)
@@ -70,4 +76,41 @@
   if leaks.nonEmpty then leaks.foreach(l => println("  LEAK: " + l))
   else println("PASS — every ratified code-string is translated in inline .tex code regions.")
 
-  if regressions.nonEmpty || leaks.nonEmpty then sys.exit(1)
+  // ---- PHASE-1 INLINE .tex COMPILE GATE (#951) ----
+  // Gate the display Scala-code envs the mirror actually rewrites. For each Code/CodeSmall/lstlisting body that
+  // is NOT inside an \ifswedish clamp (the mirror leaves clamped code alone, via Latex.ifswedishRanges) and that
+  // renderCodeIds changes, compile the Swedish body AND the rendered English body. REGRESSION = Swedish compiles
+  // but English does NOT. Skip if BOTH fail — many inline bodies aren't standalone-compilable (neighbour context
+  // / signature-only / script style), and self-skipping those beats false alarms. REPL* transcripts are DEFERRED
+  // to phase 2 (they need splitting on `scala>` prompts); Trace/Output aren't Scala. Uses the SAME per-file
+  // overrides as the mirror (renderCodeIds(body, extraId)) so per-file-scoped clusters (e.g. ANIMAL) are gated.
+  val phase1Envs = Set("Code", "CodeSmall", "lstlisting")
+  def stripLstOpt(body: String): String =                    // \begin{lstlisting}[opts]: the [opts] can trail on line 1
+    body.replaceFirst("(?s)\\A[ \\t]*\\[[^\\]]*\\]", "")
+  var inChecked = 0; var inSkipped = 0; var replDeferred = 0; var nonCode = 0
+  val inRegressions = collection.mutable.ArrayBuffer[String]()
+  for f <- texFiles do
+    val tex = os.read(f)
+    val rel = f.relativeTo(root).toString
+    val extraId = CodeGlossary.overridesFor(rel)
+    if !CodeGlossary.isOptedOut(rel) then
+      val clampRanges = Latex.ifswedishRanges(tex)
+      def clamped(pos: Int): Boolean = clampRanges.exists((a, b) => pos >= a && pos < b)
+      for m <- envRe.findAllMatchIn(tex) if !clamped(m.start) do
+        val env = m.group(1)
+        val body = if env == "lstlisting" then stripLstOpt(m.group(2)) else m.group(2)
+        val en = CodeGlossary.renderCodeIds(body, extraId)
+        if en != body then                                   // only REWRITTEN bodies are gate-relevant
+          if env.startsWith("REPL") then replDeferred += 1   // rewritten transcripts -> phase 2
+          else if !phase1Envs(env) then nonCode += 1         // Trace/Output — not compilable Scala
+          else if compiles(en, "Inline.scala") then inChecked += 1
+          else if compiles(body, "Inline.scala") then
+            inRegressions += s"$rel ($env)"
+            println(s"  INLINE REGRESSION: $rel ($env) — compiles in Swedish but NOT after rename")
+          else inSkipped += 1
+  println(s"\n=== inline .tex compile gate (phase 1): $inChecked ok, $inSkipped skipped (not standalone), " +
+    s"$replDeferred REPL deferred to phase 2, $nonCode Trace/Output not gated, ${inRegressions.size} REGRESSIONS ===")
+  if inRegressions.nonEmpty then println("FAIL — inline translation broke compilation in: " + inRegressions.mkString(", "))
+  else println("PASS — every rewritten, self-contained inline Scala-code env still compiles.")
+
+  if regressions.nonEmpty || leaks.nonEmpty || inRegressions.nonEmpty then sys.exit(1)

--- a/autotranslate/scratch/verify-mirror-examples.scala
+++ b/autotranslate/scratch/verify-mirror-examples.scala
@@ -27,7 +27,10 @@
 //   scala-cli run autotranslate/scratch/verify-mirror-examples.scala -- <introprog-root>
 //   (exit 0 = clean, exit 1 = at least one regression or an untranslated ratified code-string)
 
-@main def verifyMirrorExamples(rootStr: String): Unit =
+@main def verifyMirrorExamples(args: String*): Unit =
+  val rootStr = args.find(a => !a.startsWith("--")).getOrElse(".")
+  val listMode = args.contains("--list")   // also print the per-body phase-1 classification (file:line (env))
+  def lineOf(s: String, pos: Int): Int = s.substring(0, pos).count(_ == '\n') + 1
   val root = os.Path(rootStr, os.pwd)
   val dir = root / "compendium" / "examples"   // workspace/ is served by the hand-maintained workspace-en
   val files =
@@ -89,6 +92,8 @@
     body.replaceFirst("(?s)\\A[ \\t]*\\[[^\\]]*\\]", "")
   var inChecked = 0; var inSkipped = 0; var replDeferred = 0; var nonCode = 0
   val inRegressions = collection.mutable.ArrayBuffer[String]()
+  val inOk = collection.mutable.ArrayBuffer[String]()      // file:line (env) of each OK body (for --list)
+  val inSkip = collection.mutable.ArrayBuffer[String]()    // file:line (env) of each skipped body (for --list)
   for f <- texFiles do
     val tex = os.read(f)
     val rel = f.relativeTo(root).toString
@@ -103,14 +108,19 @@
         if en != body then                                   // only REWRITTEN bodies are gate-relevant
           if env.startsWith("REPL") then replDeferred += 1   // rewritten transcripts -> phase 2
           else if !phase1Envs(env) then nonCode += 1         // Trace/Output — not compilable Scala
-          else if compiles(en, "Inline.scala") then inChecked += 1
+          else if compiles(en, "Inline.scala") then { inChecked += 1; inOk += s"$rel:${lineOf(tex, m.start)} ($env)" }
           else if compiles(body, "Inline.scala") then
             inRegressions += s"$rel ($env)"
             println(s"  INLINE REGRESSION: $rel ($env) — compiles in Swedish but NOT after rename")
-          else inSkipped += 1
+          else { inSkipped += 1; inSkip += s"$rel:${lineOf(tex, m.start)} ($env)" }
   println(s"\n=== inline .tex compile gate (phase 1): $inChecked ok, $inSkipped skipped (not standalone), " +
     s"$replDeferred REPL deferred to phase 2, $nonCode Trace/Output not gated, ${inRegressions.size} REGRESSIONS ===")
   if inRegressions.nonEmpty then println("FAIL — inline translation broke compilation in: " + inRegressions.mkString(", "))
   else println("PASS — every rewritten, self-contained inline Scala-code env still compiles.")
+  if listMode then
+    println(s"\n--- phase-1 OK (${inOk.size}) — rewritten inline envs that compile after rename ---")
+    inOk.foreach(s => println(s"  ok   $s"))
+    println(s"--- phase-1 SKIPPED (${inSkip.size}) — rewritten inline envs that compile in NEITHER language (not standalone) ---")
+    inSkip.foreach(s => println(s"  skip $s"))
 
   if regressions.nonEmpty || leaks.nonEmpty || inRegressions.nonEmpty then sys.exit(1)

--- a/compendium/modules/w10-inheritance-exercise.tex
+++ b/compendium/modules/w10-inheritance-exercise.tex
@@ -1252,9 +1252,9 @@ scala> (new Sub).vårHemlis
 
 \Task  \what~  Den flitige ornitologen från uppgift \ref{task:fyle} ska ringmärka alla 42 fåglar hen hittat i skogen. När hen ändå håller på bestämmer hen att även försöka ta reda på hur mycket oväsen som skapas av respektive fågelsort. För detta ändamål apterar den flitige ornitologen en Linuxdator på allt infångat fyle. Du ska hjälpa ornitologen att skriva programmet.
 
-\Subtask Inför en \code{protected var räknaLäte} i traiten \code{Fyle} och skriv kod på lämpliga ställen för att räkna hur många läten som respektive fågelinstans yttrar.
+\Subtask Inför en \ifswedish\code{protected var räknaLäte}\else\code{protected var callCount}\fi{} i traiten \ifswedish\code{Fyle}\else\code{Fowlk}\fi{} och skriv kod på lämpliga ställen för att räkna hur många läten som respektive fågelinstans yttrar.
 
-\Subtask Inför en metod \code{antalLäten} som returnerar antalet krax respektive kvack som en viss fågel yttrat sedan dess skapelse.
+\Subtask Inför en metod \ifswedish\code{antalLäten}\else\code{numberOfCalls}\fi{} som returnerar antalet krax respektive kvack som en viss fågel yttrat sedan dess skapelse.
 
 \Subtask Varför inte använda \code{private} i stället for \code{protected}?
 
@@ -1268,17 +1268,23 @@ scala> (new Sub).vårHemlis
 \TaskSolved \what
 
 
-\SubtaskSolved  I Fyle:
+\SubtaskSolved  \ifswedish I Fyle:
 \begin{Code}
 protected var räknaLäte: Int = 0
 def väsnas: Unit = { print(läte * 2); räknaLäte += 2 }
 \end{Code}
+\else In Fowlk:
+\begin{Code}
+protected var callCount: Int = 0
+def holler: Unit = { print(call * 2); callCount += 2 }
+\end{Code}
+\fi
 
-I Ånka: \code| override def väsnas = { print(läte * 4); räknaLäte += 4 }|
+\ifswedish I Ånka: \code| override def väsnas = { print(läte * 4); räknaLäte += 4 }|\else In Quaddle: \code| override def holler = { print(call * 4); callCount += 4 }|\fi
 
-\SubtaskSolved  \code{ def antalLäten: Int = räknaLäte }
+\SubtaskSolved  \ifswedish\code{ def antalLäten: Int = räknaLäte }\else\code{ def numberOfCalls: Int = callCount }\fi
 
-\SubtaskSolved  Om en klass som representerar en fågel som skulle ge ifrån sig fler/färre läten än en vanlig \code{Fyle}, behöver \code{väsnas} ändras. Denna metod behöver tillgång till \code{räknaLäte}, vilken inte får vara \code{private}.
+\SubtaskSolved  Om en klass som representerar en fågel som skulle ge ifrån sig fler/färre läten än en vanlig \ifswedish\code{Fyle}\else\code{Fowlk}\fi{}, behöver \ifswedish\code{väsnas}\else\code{holler}\fi{} ändras. Denna metod behöver tillgång till \ifswedish\code{räknaLäte}\else\code{callCount}\fi{}, vilken inte får vara \code{private}.
 
 \SubtaskSolved  Räknar-variabeln ska inte kunna påverkas i någon annan del av programmet.
 
@@ -1335,12 +1341,12 @@ final class Pjodd extends Fyle, KanFlyga, KanKanskeSimma, ÄrLiten:
 \begin{Code}
 trait Fowlk:
   val call: String
-  def holler: Unit = { print(call * 2); callTally += 2 }
-  protected var callTally: Int = 0
+  def holler: Unit = { print(call * 2); callCount += 2 }
+  protected var callCount: Int = 0
   val canActuallySwim: Boolean
   val canActuallyFly: Boolean
   val isLarge : Boolean
-  def callCount: Int = callTally
+  def numberOfCalls: Int = callCount
 
 trait CanSwim { val canActuallySwim = true }
 trait CannotSwim { val canActuallySwim = false }
@@ -1355,11 +1361,11 @@ final class Crawke extends Fowlk, CanFly, CannotSwim, IsLarge:
 
 final class Quaddle extends Fowlk, CanSwim, CanPerhapsFly, IsLarge:
   val call = "quawk"
-  override def holler = { print(call * 4); callTally += 4 }
+  override def holler = { print(call * 4); callCount += 4 }
 
 final class Pibb extends Fowlk, CanFly, CanPerhapsSwim, IsSmall:
   val call = "chitter"
-  override def holler = { print(call * 8); callTally += 8 }
+  override def holler = { print(call * 8); callCount += 8 }
 \end{Code}
 \fi
 


### PR DESCRIPTION
Post-merge follow-ups to #948/#949 from BR's review, all verified in a rebuilt `compendium-en.pdf`.

## Changes
1. **Drop the `inmixning supertyp` override** — BR fixed the missing comma at source (`plan/Plan.scala`, 53730d5, closes #952), so the concept-list item is now two concepts (`inmixning`→mixin, `supertyp`→supertype) translating on their own. The #949 workaround is removed. (Left the wrong `inmixning supterp` cache row purged, not restored — it's dead now; say if you'd rather have a literal revert.)

2. **Scope the ANIMAL cluster to `perFileId["w10-inheritance-exercise"]`** (was global). `Djur` also occurs in `lect-w11-context`'s generics demo (`class Katt/Hund extends Djur`), where a global `Djur→Animal` produced mixed `class Katt extends Animal`. Scoping keeps w11 fully Swedish (deferred) while Task 3 still translates. The rest of the cluster occurs only in this file.

3. **Mirror leaves code inside `\ifswedish` clamps untranslated** — `translateCodeEnvBodies` was running `renderCodeIds` on code inside hand-written `\ifswedish…\else…\fi` clamps, mutating the Swedish branch into a mixed listing (the hand-clamped Fyle example rendered `def makeNoise … print(läte*2)`). New `Latex.ifswedishRanges` (nesting-aware) gives the clamp ranges; both the env pass and inline pass skip matches inside them.

4. **Ratified terms** (BR): `IckeAkademiker→NonAcademic`; `Doktorand→"PhD student"` (title string → `codeStr`); lowercase `akademiker→academic`, `forskare→researcher` (Task 5 REPL val names).

5. **Clamp the Fyle `räknaLäte` solution** — the one Fyle block that wasn't `\ifswedish`-clamped, so `väsnas` collided (must be `makeNoise` in Task 3 but `holler` in Fyle — same file, unresolvable by glossary). Hand-clamped using the Fyle example's established terms (`väsnas→holler`, `läte→call`, `Fyle→Fowlk`) plus new `räknaLäte→callCount`, `antalLäten→numberOfCalls`. Re-termed BR's existing Pjodd `\else` clamp (was `callTally`/`callCount`) to the same scheme so both solutions read consistently. Swedish branches kept byte-identical.

## Verification
- Full `compendium-en.pdf` rebuilt: Task 3 (Animal/makeNoise/Mooooo), Task 5 (Person/Academic/Researcher/NonAcademic, `"PhD student"`, `val academic`/`researcher`), main Fyle example (Fowlk/holler/call), both Fyle solutions (callCount/numberOfCalls, no mixing), w11 block consistently Swedish, concept list (`mixin`/`supertype` separate). No `makeNoise`+`läte` mixing anywhere; no `callTally` left.
- Compile+leak gate: 10 ok, 0 regressions; 293 `.tex`, 0 code-string leaks.

## Notes for BR
- `räknaLäte→callCount`, `antalLäten→numberOfCalls` are the two identifiers I coined (BR-ratified) — the rest reuse your Fyle `\else` terms.
- Pre-existing prose mistranslations in the räknaLäte subtask question ("Before a method…", "a certain frog") are model/cache issues, unrelated to this PR — flag if you'd like them addressed separately.



## Phase-1 inline compile gate (#951)
Adds the inline-`.tex` compile gate BR scoped in #951, as a second check in `scratch/verify-mirror-examples.scala`:
- Gates the display Scala-code envs the mirror rewrites (`Code`/`CodeSmall`/`lstlisting`) that `renderCodeIds` actually changes and that aren't inside an `\ifswedish` clamp (reuses the new `Latex.ifswedishRanges`, so it gates exactly the set the mirror translates).
- Same regression rule as the #950 `.scala` gate: compile the Swedish body and the rendered English body; **regression = Swedish compiles but English doesn't**; skip if both fail (neighbour-context/signature-only/script-style bodies self-skip). Strips a leading `lstlisting[...]` option line first. Uses the mirror's per-file overrides so per-file clusters (ANIMAL) are gated too.
- **REPL transcripts deferred to phase 2** (need splitting on `scala>` prompts); Trace/Output aren't compilable Scala. Both counts are `log()`-ed so nothing silently reads as "covered".

**Tested (not just run clean):** 23 self-contained inline bodies compile (non-vacuous); an injected `Tomat→Tomato` duplicate-class rename is caught (exit 1) while a `\ifswedish`-clamped copy of the same break is correctly skipped; robust to a missing `examples/` dir.
