### PR TITLE
autotranslate: phase-2 REPL compile gate (#951)

### DIFF
--- a/autotranslate/CodeGlossary.scala
+++ b/autotranslate/CodeGlossary.scala
@@ -49,17 +49,15 @@ object CodeGlossary:
     "Kanske" -> "Maybe", "Någon" -> "Just", "Ingen" -> "Empty",
     // PERSON cluster (personExample*.scala + lect-w10-override) — BR-ratified 2026-07-19 (#942).
     "namn" -> "name", "ålder" -> "age", "universitet" -> "university", "titel" -> "title",
-    "Akademiker" -> "Academic", "Forskare" -> "Researcher",
+    "Akademiker" -> "Academic", "Forskare" -> "Researcher", "IckeAkademiker" -> "NonAcademic",
     // one-off example identifiers surfaced by the #944 coverage sweep — BR-ratified 2026-07-19 (#942).
     "Examinerad" -> "Graduated",                                       // trait Graduated { val title: String }
     "kastaTärningTillsAllaUtfallUtomEtt" -> "rollDieUntilAllOutcomesExceptOne",
     "BaklängesHandler" -> "BackwardsHandler",
-    // ANIMAL cluster (w10-inheritance-exercise Task 3, `trait Djur`) — BR-agreed 2026-07-20.
-    // Inline .tex code (REPL/Code envs + prose \code{}) → translated by the mirror's inline pass (#948).
-    // The onomatopoeia string literals (Muuuuuuu/Nöffnöff/Gnääääägg) are English sounds too — via `codeStr`
-    // (whole-literal match applied inside string literals by renderCodeIds), NOT this id map.
-    "Djur" -> "Animal", "Ko" -> "Cow", "Gris" -> "Pig", "Häst" -> "Horse",
-    "väsnas" -> "makeNoise", "skapaDjur" -> "createAnimal", "bondgård" -> "farm",
+    // NB: the ANIMAL cluster (Djur/Ko/Gris/Häst/väsnas/skapaDjur/bondgård) is NOT global — it lives in
+    // `perFileId` scoped to w10-inheritance-exercise. `Djur` also occurs in lect-w11-context's generics demo
+    // (class Katt/Hund extends Djur) where Katt/Hund aren't in the glossary; a global Djur->Animal rendered
+    // `class Katt extends Animal` (mixed). Scoping keeps w11 fully Swedish until that lecture is translated.
   )
   // string / comment inner text (longest first so a prefix doesn't pre-empt). exact substring replace.
   val str: Seq[(String, String)] = Seq(
@@ -192,6 +190,14 @@ object CodeGlossary:
   // need nothing here (their clamps are masked verbatim, so the mirror pass leaves them alone).
   val perFileId: Map[String, Map[String, String]] = Map(
     // e.g. "w01-kojo" -> Map("Färg" -> "Colour", "Röd" -> "Red", "Svart" -> "Black")
+    // ANIMAL cluster — scoped here (NOT global) so `Djur` doesn't bleed into lect-w11-context's generics demo
+    // (class Katt/Hund extends Djur, where Katt/Hund aren't glossary'd -> mixed `class Katt extends Animal`).
+    // Task 3's own Fyle-bird example in this same file is hand-clamped (\ifswedish), so the mirror leaves it
+    // alone (Latex.ifswedishRanges); only Task 3's unclamped REPL/Code envs get these. BR-agreed 2026-07-20.
+    "w10-inheritance-exercise" -> Map(
+      "Djur" -> "Animal", "Ko" -> "Cow", "Gris" -> "Pig", "Häst" -> "Horse",
+      "väsnas" -> "makeNoise", "skapaDjur" -> "createAnimal", "bondgård" -> "farm",
+    ),
   )
   // Mirror-relative path substrings whose inline Scala-code envs SKIP the renderCodeIds pass entirely.
   val optOut: Set[String] = Set()

--- a/autotranslate/CodeGlossary.scala
+++ b/autotranslate/CodeGlossary.scala
@@ -50,6 +50,9 @@ object CodeGlossary:
     // PERSON cluster (personExample*.scala + lect-w10-override) — BR-ratified 2026-07-19 (#942).
     "namn" -> "name", "ålder" -> "age", "universitet" -> "university", "titel" -> "title",
     "Akademiker" -> "Academic", "Forskare" -> "Researcher", "IckeAkademiker" -> "NonAcademic",
+    // lowercase val-name forms (Task 5 REPL: `val akademiker = new Academic(...)`) — same words as the classes
+    // above, just lowercased per Scala val-naming convention — BR-ratified 2026-07-21.
+    "akademiker" -> "academic", "forskare" -> "researcher",
     // one-off example identifiers surfaced by the #944 coverage sweep — BR-ratified 2026-07-19 (#942).
     "Examinerad" -> "Graduated",                                       // trait Graduated { val title: String }
     "kastaTärningTillsAllaUtfallUtomEtt" -> "rollDieUntilAllOutcomesExceptOne",
@@ -105,6 +108,8 @@ object CodeGlossary:
   val codeStr: Map[String, String] = Map(
     // ANIMAL cluster onomatopoeia (w10-inheritance-exercise Task 3) — BR-ratified 2026-07-20: English sounds.
     "Muuuuuuu" -> "Mooooo", "Nöffnöff" -> "Oink", "Gnääääägg" -> "Neigh",
+    // PERSON: the researcher's title value (Task 5 REPL: new Researcher(..., "Doktorand")) — BR-ratified 2026-07-21.
+    "Doktorand" -> "PhD student",
   )
 
   private val tok: Regex = "[A-Za-zÅÄÖåäö_][A-Za-z0-9ÅÄÖåäö_]*".r

--- a/autotranslate/Latex.scala
+++ b/autotranslate/Latex.scala
@@ -141,6 +141,19 @@ object Latex:
       else i += 1
     i
 
+  /** Character ranges `[start, end)` of every top-level `\ifswedish...\fi` block (nesting-aware via matchFi).
+    * The mirror's code-env / inline-code translation uses this to LEAVE hand-clamped code alone: both branches
+    * of a `\ifswedish<sv>\else<en>\fi` clamp are already final, so translating inside one would mutate the
+    * Swedish branch (e.g. rename `väsnas`->`makeNoise` while its neighbours stay Swedish -> a mixed listing). */
+  def ifswedishRanges(s: String): Seq[(Int, Int)] =
+    val out = scala.collection.mutable.ArrayBuffer[(Int, Int)]()
+    val tag = "\\ifswedish"; var i = 0
+    while i >= 0 && i < s.length do
+      val k = s.indexOf(tag, i)
+      if k < 0 then i = -1
+      else { val end = matchFi(s, k + tag.length); out += ((k, end)); i = end }
+    out.toSeq
+
   /** Mask the source. Returns (maskedText, spans, itemIdx) where itemIdx is the set of placeholder
     * indices that are `\item` markers (used to split bullet lists into per-item translation units).
     * With stripEng=true, `\Eng{...}` is removed. */

--- a/autotranslate/Overrides.scala
+++ b/autotranslate/Overrides.scala
@@ -42,13 +42,14 @@ object Overrides:
     "alternativ"          -> "selection",
     "repetition"          -> "repetition",
     "identifierare"       -> "identifier",
-    // standalone concept-list items (\item topptyp / \item bottentyp / \item inmixning supertyp in w10-chaphead):
-    // the model mangled these compound words — "topptyp"/"bottentyp" into camelCase pseudo-identifiers
-    // ("topptype"/"bottomType"), and "inmixning supertyp" into a half-translated "mixin supertyp" (supertyp left
-    // Swedish, though the standalone "supertyp" row is "supertype"). Override to the correct terms. (Cache rows purged.)
+    // standalone concept-list items (\item topptyp / \item bottentyp in w10-chaphead): the model mangled these
+    // compound words into camelCase pseudo-identifiers ("topptype"/"bottomType"). The CONTEXTUAL rows already
+    // say "top type"/"bottom type"; override the standalone ones to match. (Wrong cache rows purged.)
+    // (The former `inmixning supertyp` -> `mixin supertype` override was dropped once BR fixed the missing comma
+    //  at plan/Plan.scala (53730d5, #952): that item is now two separate concepts, `inmixning`->mixin and
+    //  `supertyp`->supertype, each translating on its own via existing cache rows.)
     "topptyp"             -> "top type",
     "bottentyp"           -> "bottom type",
-    "inmixning supertyp"  -> "mixin supertype",
     "slumptal"            -> "random number",
     "dod: operativsystem" -> "dod: operating system",
     "Denna kurs behandlar de tre första." -> "This course covers the first three.", // paradigms slide; model fallback kept Swedish

--- a/autotranslate/Translate.scala
+++ b/autotranslate/Translate.scala
@@ -658,14 +658,27 @@ object Translate:
   def translateCodeEnvBodies(tex: String, relPath: String = ""): String =
     val extraId = CodeGlossary.overridesFor(relPath)
     val doIds = !CodeGlossary.isOptedOut(relPath)
+    // Leave code inside `\ifswedish...\fi` clamps alone: both branches are hand-final, so translating there
+    // would mutate the Swedish branch into a mixed listing (e.g. `def makeNoise` next to `print(läte*2)` in the
+    // hand-clamped Fyle example). Ranges computed on the ORIGINAL text; matches keep their original offsets
+    // because replaceAllIn scans left-to-right and we test m.start against the pre-substitution positions.
+    val protectedRanges = Latex.ifswedishRanges(tex)
+    def clamped(pos: Int): Boolean = protectedRanges.exists((a, b) => pos >= a && pos < b)
     val envAlt = codeEnvs.toSeq.map(java.util.regex.Pattern.quote).mkString("|")
     val re = ("(?s)(\\\\begin\\{(" + envAlt + ")\\})(.*?)(\\\\end\\{\\2\\})").r
     val withEnvs = re.replaceAllIn(tex, m =>
-      val body = if doIds && scalaCodeEnvs(m.group(2)) then CodeGlossary.renderCodeIds(m.group(3), extraId) else m.group(3)
-      java.util.regex.Matcher.quoteReplacement(m.group(1) + Code.translate(body, translatePlain, skipTexComments = true) + m.group(4)))
+      if clamped(m.start) then java.util.regex.Matcher.quoteReplacement(m.matched)
+      else
+        val body = if doIds && scalaCodeEnvs(m.group(2)) then CodeGlossary.renderCodeIds(m.group(3), extraId) else m.group(3)
+        java.util.regex.Matcher.quoteReplacement(m.group(1) + Code.translate(body, translatePlain, skipTexComments = true) + m.group(4)))
     if !doIds then withEnvs
-    else inlineCodeRe.replaceAllIn(withEnvs, m =>
-      java.util.regex.Matcher.quoteReplacement(s"\\${m.group(1)}{" + CodeGlossary.renderCodeIds(m.group(2), extraId) + "}"))
+    else
+      // the env pass changed lengths, so recompute clamp ranges against `withEnvs` for the inline pass.
+      val inlineRanges = Latex.ifswedishRanges(withEnvs)
+      def clampedInline(pos: Int): Boolean = inlineRanges.exists((a, b) => pos >= a && pos < b)
+      inlineCodeRe.replaceAllIn(withEnvs, m =>
+        if clampedInline(m.start) then java.util.regex.Matcher.quoteReplacement(m.matched)
+        else java.util.regex.Matcher.quoteReplacement(s"\\${m.group(1)}{" + CodeGlossary.renderCodeIds(m.group(2), extraId) + "}"))
 
   // ---------- lifecycle ----------
   /** Load cache and make sure the model is ready (called before mirror translation).

--- a/autotranslate/scratch/verify-mirror-examples.scala
+++ b/autotranslate/scratch/verify-mirror-examples.scala
@@ -2,6 +2,7 @@
 //> using jvm 21
 //> using dep com.lihaoyi::os-lib:0.11.8
 //> using file ../CodeGlossary.scala
+//> using file ../Latex.scala
 
 // COMPILE GATE for the mirror's example-code translation (#947/#948 + the personExample s-interp fix).
 // "Only compilable code should pass": every example .scala/.java that CodeGlossary.renderCodeIds rewrites
@@ -19,14 +20,19 @@
 // key surviving in a rendered Scala-code env / inline \code fails the gate — so a ratified sound can't regress
 // to Swedish, and a NEW sound added to a .tex but not to codeStr is caught.
 //
+// Plus a PHASE-1 INLINE .tex COMPILE GATE (#951): the same regression rule applied to the display Scala-code
+// envs (Code/CodeSmall/lstlisting) the mirror rewrites in .tex — skipping \ifswedish-clamped code and deferring
+// REPL transcripts to phase 2. See that section below.
+//
 //   scala-cli run autotranslate/scratch/verify-mirror-examples.scala -- <introprog-root>
 //   (exit 0 = clean, exit 1 = at least one regression or an untranslated ratified code-string)
 
 @main def verifyMirrorExamples(rootStr: String): Unit =
   val root = os.Path(rootStr, os.pwd)
   val dir = root / "compendium" / "examples"   // workspace/ is served by the hand-maintained workspace-en
-  val files = os.walk(dir).filter(f => os.isFile(f) && (f.ext == "scala" || f.ext == "java"))
-    .sortBy(_.toString)
+  val files =
+    if !os.exists(dir) then Seq.empty[os.Path]
+    else os.walk(dir).filter(f => os.isFile(f) && (f.ext == "scala" || f.ext == "java")).sortBy(_.toString)
   def compiles(code: String, name: String): Boolean =
     val tmp = os.temp.dir(prefix = "mirror-gate")          // keep the original filename (Java needs it)
     os.write.over(tmp / name, code)
@@ -70,4 +76,41 @@
   if leaks.nonEmpty then leaks.foreach(l => println("  LEAK: " + l))
   else println("PASS — every ratified code-string is translated in inline .tex code regions.")
 
-  if regressions.nonEmpty || leaks.nonEmpty then sys.exit(1)
+  // ---- PHASE-1 INLINE .tex COMPILE GATE (#951) ----
+  // Gate the display Scala-code envs the mirror actually rewrites. For each Code/CodeSmall/lstlisting body that
+  // is NOT inside an \ifswedish clamp (the mirror leaves clamped code alone, via Latex.ifswedishRanges) and that
+  // renderCodeIds changes, compile the Swedish body AND the rendered English body. REGRESSION = Swedish compiles
+  // but English does NOT. Skip if BOTH fail — many inline bodies aren't standalone-compilable (neighbour context
+  // / signature-only / script style), and self-skipping those beats false alarms. REPL* transcripts are DEFERRED
+  // to phase 2 (they need splitting on `scala>` prompts); Trace/Output aren't Scala. Uses the SAME per-file
+  // overrides as the mirror (renderCodeIds(body, extraId)) so per-file-scoped clusters (e.g. ANIMAL) are gated.
+  val phase1Envs = Set("Code", "CodeSmall", "lstlisting")
+  def stripLstOpt(body: String): String =                    // \begin{lstlisting}[opts]: the [opts] can trail on line 1
+    body.replaceFirst("(?s)\\A[ \\t]*\\[[^\\]]*\\]", "")
+  var inChecked = 0; var inSkipped = 0; var replDeferred = 0; var nonCode = 0
+  val inRegressions = collection.mutable.ArrayBuffer[String]()
+  for f <- texFiles do
+    val tex = os.read(f)
+    val rel = f.relativeTo(root).toString
+    val extraId = CodeGlossary.overridesFor(rel)
+    if !CodeGlossary.isOptedOut(rel) then
+      val clampRanges = Latex.ifswedishRanges(tex)
+      def clamped(pos: Int): Boolean = clampRanges.exists((a, b) => pos >= a && pos < b)
+      for m <- envRe.findAllMatchIn(tex) if !clamped(m.start) do
+        val env = m.group(1)
+        val body = if env == "lstlisting" then stripLstOpt(m.group(2)) else m.group(2)
+        val en = CodeGlossary.renderCodeIds(body, extraId)
+        if en != body then                                   // only REWRITTEN bodies are gate-relevant
+          if env.startsWith("REPL") then replDeferred += 1   // rewritten transcripts -> phase 2
+          else if !phase1Envs(env) then nonCode += 1         // Trace/Output — not compilable Scala
+          else if compiles(en, "Inline.scala") then inChecked += 1
+          else if compiles(body, "Inline.scala") then
+            inRegressions += s"$rel ($env)"
+            println(s"  INLINE REGRESSION: $rel ($env) — compiles in Swedish but NOT after rename")
+          else inSkipped += 1
+  println(s"\n=== inline .tex compile gate (phase 1): $inChecked ok, $inSkipped skipped (not standalone), " +
+    s"$replDeferred REPL deferred to phase 2, $nonCode Trace/Output not gated, ${inRegressions.size} REGRESSIONS ===")
+  if inRegressions.nonEmpty then println("FAIL — inline translation broke compilation in: " + inRegressions.mkString(", "))
+  else println("PASS — every rewritten, self-contained inline Scala-code env still compiles.")
+
+  if regressions.nonEmpty || leaks.nonEmpty || inRegressions.nonEmpty then sys.exit(1)

--- a/autotranslate/scratch/verify-mirror-examples.scala
+++ b/autotranslate/scratch/verify-mirror-examples.scala
@@ -27,7 +27,10 @@
 //   scala-cli run autotranslate/scratch/verify-mirror-examples.scala -- <introprog-root>
 //   (exit 0 = clean, exit 1 = at least one regression or an untranslated ratified code-string)
 
-@main def verifyMirrorExamples(rootStr: String): Unit =
+@main def verifyMirrorExamples(args: String*): Unit =
+  val rootStr = args.find(a => !a.startsWith("--")).getOrElse(".")
+  val listMode = args.contains("--list")   // also print the per-body phase-1 classification (file:line (env))
+  def lineOf(s: String, pos: Int): Int = s.substring(0, pos).count(_ == '\n') + 1
   val root = os.Path(rootStr, os.pwd)
   val dir = root / "compendium" / "examples"   // workspace/ is served by the hand-maintained workspace-en
   val files =
@@ -89,6 +92,8 @@
     body.replaceFirst("(?s)\\A[ \\t]*\\[[^\\]]*\\]", "")
   var inChecked = 0; var inSkipped = 0; var replDeferred = 0; var nonCode = 0
   val inRegressions = collection.mutable.ArrayBuffer[String]()
+  val inOk = collection.mutable.ArrayBuffer[String]()      // file:line (env) of each OK body (for --list)
+  val inSkip = collection.mutable.ArrayBuffer[String]()    // file:line (env) of each skipped body (for --list)
   for f <- texFiles do
     val tex = os.read(f)
     val rel = f.relativeTo(root).toString
@@ -103,14 +108,19 @@
         if en != body then                                   // only REWRITTEN bodies are gate-relevant
           if env.startsWith("REPL") then replDeferred += 1   // rewritten transcripts -> phase 2
           else if !phase1Envs(env) then nonCode += 1         // Trace/Output — not compilable Scala
-          else if compiles(en, "Inline.scala") then inChecked += 1
+          else if compiles(en, "Inline.scala") then { inChecked += 1; inOk += s"$rel:${lineOf(tex, m.start)} ($env)" }
           else if compiles(body, "Inline.scala") then
             inRegressions += s"$rel ($env)"
             println(s"  INLINE REGRESSION: $rel ($env) — compiles in Swedish but NOT after rename")
-          else inSkipped += 1
+          else { inSkipped += 1; inSkip += s"$rel:${lineOf(tex, m.start)} ($env)" }
   println(s"\n=== inline .tex compile gate (phase 1): $inChecked ok, $inSkipped skipped (not standalone), " +
     s"$replDeferred REPL deferred to phase 2, $nonCode Trace/Output not gated, ${inRegressions.size} REGRESSIONS ===")
   if inRegressions.nonEmpty then println("FAIL — inline translation broke compilation in: " + inRegressions.mkString(", "))
   else println("PASS — every rewritten, self-contained inline Scala-code env still compiles.")
+  if listMode then
+    println(s"\n--- phase-1 OK (${inOk.size}) — rewritten inline envs that compile after rename ---")
+    inOk.foreach(s => println(s"  ok   $s"))
+    println(s"--- phase-1 SKIPPED (${inSkip.size}) — rewritten inline envs that compile in NEITHER language (not standalone) ---")
+    inSkip.foreach(s => println(s"  skip $s"))
 
   if regressions.nonEmpty || leaks.nonEmpty || inRegressions.nonEmpty then sys.exit(1)

--- a/autotranslate/scratch/verify-mirror-examples.scala
+++ b/autotranslate/scratch/verify-mirror-examples.scala
@@ -182,4 +182,20 @@
     println(s"--- phase-2 SKIPPED (${rpSkip.size}) — REPL transcripts that compile in NEITHER language / no input ---")
     rpSkip.foreach(s => println(s"  skip $s"))
 
+  // @later (#951 phase 3) — cross-env context. PARKED 2026-07-22 (deferred; pending BR): the ~81 code-bearing skips above
+  // (30 inline + 51 REPL-with-input) mostly compile in neither language because they reference names DEFINED in a
+  // neighbouring env, not in the body itself. Phase 3 would supply that context: group consecutive scala-code
+  // envs per file into "sessions" (reset at \Task/\Subtask/\SOLUTION/\section/\begin{Slide}/\QUESTBEGIN...),
+  // prepend the preceding same-session envs' code as a preamble — taking the \else branch for \ifswedish context
+  // envs (SV branch for the SV compile, \else for the EN compile, since defs are often hand-clamped while the
+  // referencing REPL is auto-translated) — and compile `object Session: <preamble> <body>` under the same
+  // regression rule. Env selection stays identical for SV and EN, so a mis-grouped boundary can only skip.
+  // Step 0 (static, measured on the RENDERED English side — the source side is optimistic since a ref and its
+  // def share the Swedish identifier by construction): ~20 recoverable, ~24 external (lib/cross-file/absent),
+  // ~37 unclassifiable (lowercase/expression-only). Divergence (recoverable on SV side but NOT on the mirror
+  // side, i.e. caused by INCONSISTENT translation) = 0 — so the current cross-refs that resolve in Swedish also
+  // resolve in English; there is no hidden inconsistency for phase 3 to catch. Given the moderate ~20-body gain
+  // vs the added machinery (session grouping + clamp-branch extraction), parked; phases 1–2 are the coverage
+  // line. Genuinely-external cases stay covered by the opt-out marker (reserved "option 3"). Revisit if the
+  // recoverable set (incl. the Task 3 solution Code envs + several w05/w11 cases) becomes worth gating.
   if regressions.nonEmpty || leaks.nonEmpty || inRegressions.nonEmpty || rpRegressions.nonEmpty then sys.exit(1)

--- a/autotranslate/scratch/verify-mirror-examples.scala
+++ b/autotranslate/scratch/verify-mirror-examples.scala
@@ -21,8 +21,10 @@
 // to Swedish, and a NEW sound added to a .tex but not to codeStr is caught.
 //
 // Plus a PHASE-1 INLINE .tex COMPILE GATE (#951): the same regression rule applied to the display Scala-code
-// envs (Code/CodeSmall/lstlisting) the mirror rewrites in .tex — skipping \ifswedish-clamped code and deferring
-// REPL transcripts to phase 2. See that section below.
+// envs (Code/CodeSmall/lstlisting) the mirror rewrites in .tex — skipping \ifswedish-clamped code. And a
+// PHASE-2 REPL GATE: REPL* transcripts split on `scala>` prompts, inputs concatenated into an object and
+// compiled under the same regression rule (SV/EN classification is symmetric, so a mis-split only skips).
+// See those sections below.
 //
 //   scala-cli run autotranslate/scratch/verify-mirror-examples.scala -- <introprog-root>
 //   (exit 0 = clean, exit 1 = at least one regression or an untranslated ratified code-string)
@@ -123,4 +125,61 @@
     println(s"--- phase-1 SKIPPED (${inSkip.size}) — rewritten inline envs that compile in NEITHER language (not standalone) ---")
     inSkip.foreach(s => println(s"  skip $s"))
 
-  if regressions.nonEmpty || leaks.nonEmpty || inRegressions.nonEmpty then sys.exit(1)
+  // ---- PHASE-2 INLINE REPL COMPILE GATE (#951) ----
+  // REPL transcripts: split on `scala>` prompts (prompt-stripped input + its indented continuation lines; OUTPUT
+  // lines — result echoes `val x: T = …`, `resN`, error `|`/`-- Error`, blanks — are dropped), concatenate a
+  // transcript's inputs into one `object` body and compile SV vs EN with the phase-1 regression rule. Line
+  // classification is IDENTICAL for the SV and EN transcripts (they have parallel structure), so a mis-split can
+  // only SKIP a transcript — never cause a false regression. Many transcripts reference defs from a neighbouring
+  // Code env and so compile in neither language (self-skip). Clamp-aware + changed-only + per-file overrides.
+  val replEnvs = Set("REPL", "REPLnonum", "REPLsmall")
+  val promptLineRe = raw"^[ \t]*scala>[ ]?(.*)".r
+  val replOutRe = raw"^[ \t]*(val res\d|res\d+:|[|]|\d+ *[|]|-- (Error|Warning)|<console>|\^).*".r
+  def replProgram(bodyStr: String): String =
+    val prog = collection.mutable.ArrayBuffer[String]()
+    var inInput = false
+    for line <- bodyStr.split("\n", -1) do
+      promptLineRe.findFirstMatchIn(line) match
+        case Some(pm) => prog += pm.group(1); inInput = true          // `scala> …` input line (prompt stripped)
+        case None =>
+          val t = line.trim
+          val isOutput = t.isEmpty || replOutRe.findFirstMatchIn(line).isDefined ||
+            t.matches("(val|var)\\s+\\w+:.*=.*")                      // result-echo `val x: T = …`
+          if inInput && !isOutput then prog += line                  // continuation of a multi-line input
+          else inInput = false
+    prog.mkString("\n")
+  def wrapObj(prog: String): String =
+    "object ReplWrap:\n" + prog.split("\n", -1).map("  " + _).mkString("\n")
+  var rpChecked = 0; var rpSkipped = 0
+  val rpRegressions = collection.mutable.ArrayBuffer[String]()
+  val rpOk = collection.mutable.ArrayBuffer[String]()      // file:line of each OK transcript (for --list)
+  val rpSkip = collection.mutable.ArrayBuffer[String]()    // file:line of each skipped transcript (for --list)
+  for f <- texFiles do
+    val tex = os.read(f)
+    val rel = f.relativeTo(root).toString
+    val extraId = CodeGlossary.overridesFor(rel)
+    if !CodeGlossary.isOptedOut(rel) then
+      val clampRanges = Latex.ifswedishRanges(tex)
+      def clamped(pos: Int): Boolean = clampRanges.exists((a, b) => pos >= a && pos < b)
+      for m <- envRe.findAllMatchIn(tex) if replEnvs(m.group(1)) && !clamped(m.start) do
+        val body = stripLstOpt(m.group(2))                           // strip a leading [numbers=none] optional arg
+        val en = CodeGlossary.renderCodeIds(body, extraId)
+        if en != body then
+          val loc = s"$rel:${lineOf(tex, m.start)}"
+          val enProg = replProgram(en)
+          if enProg.trim.isEmpty then { rpSkipped += 1; rpSkip += s"$loc (no scala> input)" }
+          else if compiles(wrapObj(enProg), "ReplWrap.scala") then { rpChecked += 1; rpOk += loc }
+          else if compiles(wrapObj(replProgram(body)), "ReplWrap.scala") then
+            rpRegressions += loc
+            println(s"  REPL REGRESSION: $loc — transcript compiles in Swedish but NOT after rename")
+          else { rpSkipped += 1; rpSkip += loc }
+  println(s"\n=== inline .tex REPL compile gate (phase 2): $rpChecked ok, $rpSkipped skipped (not standalone), ${rpRegressions.size} REGRESSIONS ===")
+  if rpRegressions.nonEmpty then println("FAIL — REPL translation broke compilation in: " + rpRegressions.mkString(", "))
+  else println("PASS — every rewritten, self-contained REPL transcript still compiles.")
+  if listMode then
+    println(s"\n--- phase-2 OK (${rpOk.size}) — rewritten REPL transcripts that compile after rename ---")
+    rpOk.foreach(s => println(s"  ok   $s"))
+    println(s"--- phase-2 SKIPPED (${rpSkip.size}) — REPL transcripts that compile in NEITHER language / no input ---")
+    rpSkip.foreach(s => println(s"  skip $s"))
+
+  if regressions.nonEmpty || leaks.nonEmpty || inRegressions.nonEmpty || rpRegressions.nonEmpty then sys.exit(1)

--- a/compendium/modules/w10-inheritance-exercise.tex
+++ b/compendium/modules/w10-inheritance-exercise.tex
@@ -1252,9 +1252,9 @@ scala> (new Sub).vårHemlis
 
 \Task  \what~  Den flitige ornitologen från uppgift \ref{task:fyle} ska ringmärka alla 42 fåglar hen hittat i skogen. När hen ändå håller på bestämmer hen att även försöka ta reda på hur mycket oväsen som skapas av respektive fågelsort. För detta ändamål apterar den flitige ornitologen en Linuxdator på allt infångat fyle. Du ska hjälpa ornitologen att skriva programmet.
 
-\Subtask Inför en \code{protected var räknaLäte} i traiten \code{Fyle} och skriv kod på lämpliga ställen för att räkna hur många läten som respektive fågelinstans yttrar.
+\Subtask Inför en \ifswedish\code{protected var räknaLäte}\else\code{protected var callCount}\fi{} i traiten \ifswedish\code{Fyle}\else\code{Fowlk}\fi{} och skriv kod på lämpliga ställen för att räkna hur många läten som respektive fågelinstans yttrar.
 
-\Subtask Inför en metod \code{antalLäten} som returnerar antalet krax respektive kvack som en viss fågel yttrat sedan dess skapelse.
+\Subtask Inför en metod \ifswedish\code{antalLäten}\else\code{numberOfCalls}\fi{} som returnerar antalet krax respektive kvack som en viss fågel yttrat sedan dess skapelse.
 
 \Subtask Varför inte använda \code{private} i stället for \code{protected}?
 
@@ -1268,17 +1268,23 @@ scala> (new Sub).vårHemlis
 \TaskSolved \what
 
 
-\SubtaskSolved  I Fyle:
+\SubtaskSolved  \ifswedish I Fyle:
 \begin{Code}
 protected var räknaLäte: Int = 0
 def väsnas: Unit = { print(läte * 2); räknaLäte += 2 }
 \end{Code}
+\else In Fowlk:
+\begin{Code}
+protected var callCount: Int = 0
+def holler: Unit = { print(call * 2); callCount += 2 }
+\end{Code}
+\fi
 
-I Ånka: \code| override def väsnas = { print(läte * 4); räknaLäte += 4 }|
+\ifswedish I Ånka: \code| override def väsnas = { print(läte * 4); räknaLäte += 4 }|\else In Quaddle: \code| override def holler = { print(call * 4); callCount += 4 }|\fi
 
-\SubtaskSolved  \code{ def antalLäten: Int = räknaLäte }
+\SubtaskSolved  \ifswedish\code{ def antalLäten: Int = räknaLäte }\else\code{ def numberOfCalls: Int = callCount }\fi
 
-\SubtaskSolved  Om en klass som representerar en fågel som skulle ge ifrån sig fler/färre läten än en vanlig \code{Fyle}, behöver \code{väsnas} ändras. Denna metod behöver tillgång till \code{räknaLäte}, vilken inte får vara \code{private}.
+\SubtaskSolved  Om en klass som representerar en fågel som skulle ge ifrån sig fler/färre läten än en vanlig \ifswedish\code{Fyle}\else\code{Fowlk}\fi{}, behöver \ifswedish\code{väsnas}\else\code{holler}\fi{} ändras. Denna metod behöver tillgång till \ifswedish\code{räknaLäte}\else\code{callCount}\fi{}, vilken inte får vara \code{private}.
 
 \SubtaskSolved  Räknar-variabeln ska inte kunna påverkas i någon annan del av programmet.
 
@@ -1335,12 +1341,12 @@ final class Pjodd extends Fyle, KanFlyga, KanKanskeSimma, ÄrLiten:
 \begin{Code}
 trait Fowlk:
   val call: String
-  def holler: Unit = { print(call * 2); callTally += 2 }
-  protected var callTally: Int = 0
+  def holler: Unit = { print(call * 2); callCount += 2 }
+  protected var callCount: Int = 0
   val canActuallySwim: Boolean
   val canActuallyFly: Boolean
   val isLarge : Boolean
-  def callCount: Int = callTally
+  def numberOfCalls: Int = callCount
 
 trait CanSwim { val canActuallySwim = true }
 trait CannotSwim { val canActuallySwim = false }
@@ -1355,11 +1361,11 @@ final class Crawke extends Fowlk, CanFly, CannotSwim, IsLarge:
 
 final class Quaddle extends Fowlk, CanSwim, CanPerhapsFly, IsLarge:
   val call = "quawk"
-  override def holler = { print(call * 4); callTally += 4 }
+  override def holler = { print(call * 4); callCount += 4 }
 
 final class Pibb extends Fowlk, CanFly, CanPerhapsSwim, IsSmall:
   val call = "chitter"
-  override def holler = { print(call * 8); callTally += 8 }
+  override def holler = { print(call * 8); callCount += 8 }
 \end{Code}
 \fi
 


### PR DESCRIPTION
Phase 2 of the inline `.tex` compile gate (#951), as BR outlined — REPL transcripts.

> **Stacked on #956** (phase-1 gate). Until #956 merges this PR's diff-vs-`master` includes #956's commits; **merge #956 first**, then this rebases down to its single commit.

## What it does
For each rewritten, non-`\ifswedish` `REPL`/`REPLnonum`/`REPLsmall` transcript:
- **Split on `scala>` prompts** — prompt-stripped input plus its indented continuation lines; output lines (result echoes `val x: T = …`, `resN`, error `|` / `-- Error`, blanks) are dropped.
- Concatenate the transcript's inputs into one `object` body and compile the **Swedish** vs **rendered-English** programs under the phase-1 regression rule: regression = Swedish compiles but English doesn't; skip if both fail.
- Clamp-aware (`Latex.ifswedishRanges`), changed-only, uses the mirror's per-file overrides.

**Safety:** line classification is *identical* for the Swedish and English transcripts (parallel structure), so a mis-split can only cause a **skip**, never a false regression.

## Tested (both paths)
- Injected `Tomat→Tomato` duplicate-class transcript → caught, **exit 1**.
- Self-contained `Gurka→Cucumber` transcript compiles → **non-vacuous**.
- `\ifswedish`-clamped copy of the same break → **skipped**.

## Clean run (real repo)
`phase 2 = 12 ok, 85 skipped, 0 regressions` (85 skipped are mostly output-only blocks with no `scala>` input, or transcripts that reference defs from a neighbouring Code env). The 12 OK include `w10-inheritance-exercise.tex:261` — the Task 3 farm REPL — so the ANIMAL rename is now compile-checked. `-- . --list` prints the per-transcript OK/skip breakdown.

Remaining known limitation: transcripts that depend on a preceding Code env compile in neither language and self-skip; wiring that cross-env context is a possible phase 3 but wasn't in scope.
