### PR TITLE
autotranslate: address review #958 (gate correctness + polish)

### DIFF
--- a/autotranslate/Latex.scala
+++ b/autotranslate/Latex.scala
@@ -145,13 +145,28 @@ object Latex:
     * The mirror's code-env / inline-code translation uses this to LEAVE hand-clamped code alone: both branches
     * of a `\ifswedish<sv>\else<en>\fi` clamp are already final, so translating inside one would mutate the
     * Swedish branch (e.g. rename `väsnas`->`makeNoise` while its neighbours stay Swedish -> a mixed listing). */
-  def ifswedishRanges(s: String): Seq[(Int, Int)] =
-    val out = scala.collection.mutable.ArrayBuffer[(Int, Int)]()
+  def ifswedishRanges(s: String): Seq[(start: Int, end: Int)] =
+    val out = scala.collection.mutable.ArrayBuffer[(start: Int, end: Int)]()
     val tag = "\\ifswedish"; var i = 0
     while i >= 0 && i < s.length do
       val k = s.indexOf(tag, i)
       if k < 0 then i = -1
-      else { val end = matchFi(s, k + tag.length); out += ((k, end)); i = end }
+      else
+        val e = matchFi(s, k + tag.length)
+        // #958.3: reached EOF without a closing \fi -> unbalanced. A stray literal \ifswedish in a comment or
+        // verbatim block opens a bogus range that swallows the rest of the file (envs after it silently go
+        // untranslated & ungated). Conservative (skip, never mistranslate). Only warn when the swallowed region
+        // actually holds a code env / inline code — otherwise it has no consequence (e.g. top-level scaffolding
+        // files with \ifswedish/\ifPreSolution conditionals whose \fi lands across an \input boundary: matchFi
+        // over-counts, but there's nothing to skip, so the warning would be pure noise).
+        if e >= s.length && !(e >= 3 && s.substring(e - 3, e) == "\\fi") then
+          val swallowed = s.substring(k, e)
+          val hasCode = verbatimEnvs.exists(env => swallowed.contains("\\begin{" + env + "}")) ||
+            swallowed.contains("\\code{") || swallowed.contains("\\jcode{") || swallowed.contains("\\lstinline{")
+          if hasCode then
+            System.err.println(s"[Latex.ifswedishRanges] WARNING: \\ifswedish at offset $k has no matching \\fi " +
+              "(range runs to end of file) and swallows code env(s): they go untranslated and ungated.")
+        out += ((start = k, end = e)); i = e
     out.toSeq
 
   /** Mask the source. Returns (maskedText, spans, itemIdx) where itemIdx is the set of placeholder

--- a/autotranslate/Translate.scala
+++ b/autotranslate/Translate.scala
@@ -668,7 +668,7 @@ object Translate:
     // hand-clamped Fyle example). Ranges computed on the ORIGINAL text; matches keep their original offsets
     // because replaceAllIn scans left-to-right and we test m.start against the pre-substitution positions.
     val protectedRanges = Latex.ifswedishRanges(tex)
-    def clamped(pos: Int): Boolean = protectedRanges.exists((a, b) => pos >= a && pos < b)
+    def clamped(pos: Int): Boolean = protectedRanges.exists(r => pos >= r.start && pos < r.end)
     val envAlt = codeEnvs.toSeq.map(java.util.regex.Pattern.quote).mkString("|")
     val re = ("(?s)(\\\\begin\\{(" + envAlt + ")\\})(.*?)(\\\\end\\{\\2\\})").r
     val withEnvs = re.replaceAllIn(tex, m =>
@@ -680,7 +680,7 @@ object Translate:
     else
       // the env pass changed lengths, so recompute clamp ranges against `withEnvs` for the inline pass.
       val inlineRanges = Latex.ifswedishRanges(withEnvs)
-      def clampedInline(pos: Int): Boolean = inlineRanges.exists((a, b) => pos >= a && pos < b)
+      def clampedInline(pos: Int): Boolean = inlineRanges.exists(r => pos >= r.start && pos < r.end)
       inlineCodeRe.replaceAllIn(withEnvs, m =>
         if clampedInline(m.start) then java.util.regex.Matcher.quoteReplacement(m.matched)
         else java.util.regex.Matcher.quoteReplacement(s"\\${m.group(1)}{" + CodeGlossary.renderCodeIds(m.group(2), extraId) + "}"))

--- a/autotranslate/scratch/verify-mirror-examples.scala
+++ b/autotranslate/scratch/verify-mirror-examples.scala
@@ -26,7 +26,9 @@
 // compiled under the same regression rule (SV/EN classification is symmetric, so a mis-split only skips).
 // See those sections below.
 //
-//   scala-cli run autotranslate/scratch/verify-mirror-examples.scala -- <introprog-root>
+//   scala-cli run autotranslate/scratch/verify-mirror-examples.scala -- [introprog-root] [--list]
+//     introprog-root  repo root to scan (optional; defaults to ".")
+//     --list          also print the per-body/-transcript OK/skip breakdown for phases 1 and 2
 //   (exit 0 = clean, exit 1 = at least one regression or an untranslated ratified code-string)
 
 @main def verifyMirrorExamples(args: String*): Unit =
@@ -69,6 +71,9 @@
   val texFiles = Seq("compendium", "slides").map(root / _).filter(os.exists)
     .flatMap(d => os.walk(d)).filter(f => os.isFile(f) && f.ext == "tex").sortBy(_.toString)
   val leaks = collection.mutable.ArrayBuffer[String]()
+  // NB (#958.6): the per-file setup (read tex, rel, extraId, opt-out, clampRanges) recurs in the two gates below.
+  // Kept as deliberate duplication — this is a scratch tool and the three loops differ enough (leak-check needs
+  // no clamp/extraId) that a shared higher-order helper would add more indirection than it removes.
   for f <- texFiles do
     val tex = os.read(f)
     def scan(body: String): Unit =
@@ -102,7 +107,7 @@
     val extraId = CodeGlossary.overridesFor(rel)
     if !CodeGlossary.isOptedOut(rel) then
       val clampRanges = Latex.ifswedishRanges(tex)
-      def clamped(pos: Int): Boolean = clampRanges.exists((a, b) => pos >= a && pos < b)
+      def clamped(pos: Int): Boolean = clampRanges.exists(r => pos >= r.start && pos < r.end)
       for m <- envRe.findAllMatchIn(tex) if !clamped(m.start) do
         val env = m.group(1)
         val body = if env == "lstlisting" then stripLstOpt(m.group(2)) else m.group(2)
@@ -112,8 +117,8 @@
           else if !phase1Envs(env) then nonCode += 1         // Trace/Output — not compilable Scala
           else if compiles(en, "Inline.scala") then { inChecked += 1; inOk += s"$rel:${lineOf(tex, m.start)} ($env)" }
           else if compiles(body, "Inline.scala") then
-            inRegressions += s"$rel ($env)"
-            println(s"  INLINE REGRESSION: $rel ($env) — compiles in Swedish but NOT after rename")
+            inRegressions += s"$rel:${lineOf(tex, m.start)} ($env)"
+            println(s"  INLINE REGRESSION: $rel:${lineOf(tex, m.start)} ($env) — compiles in Swedish but NOT after rename")
           else { inSkipped += 1; inSkip += s"$rel:${lineOf(tex, m.start)} ($env)" }
   println(s"\n=== inline .tex compile gate (phase 1): $inChecked ok, $inSkipped skipped (not standalone), " +
     s"$replDeferred REPL deferred to phase 2, $nonCode Trace/Output not gated, ${inRegressions.size} REGRESSIONS ===")
@@ -144,7 +149,10 @@
         case None =>
           val t = line.trim
           val isOutput = t.isEmpty || replOutRe.findFirstMatchIn(line).isDefined ||
-            t.matches("(val|var)\\s+\\w+:.*=.*")                      // result-echo `val x: T = …`
+            t.matches("(?U)(val|var)\\s+\\w+:.*=.*")                  // result-echo `val x: T = …`; (?U) so \w
+                                                                      // matches åäö — else `var räknaLäte:` (SV)
+                                                                      // and `var callCount:` (EN) classify
+                                                                      // differently, breaking SV/EN symmetry (#958)
           if inInput && !isOutput then prog += line                  // continuation of a multi-line input
           else inInput = false
     prog.mkString("\n")
@@ -160,7 +168,7 @@
     val extraId = CodeGlossary.overridesFor(rel)
     if !CodeGlossary.isOptedOut(rel) then
       val clampRanges = Latex.ifswedishRanges(tex)
-      def clamped(pos: Int): Boolean = clampRanges.exists((a, b) => pos >= a && pos < b)
+      def clamped(pos: Int): Boolean = clampRanges.exists(r => pos >= r.start && pos < r.end)
       for m <- envRe.findAllMatchIn(tex) if replEnvs(m.group(1)) && !clamped(m.start) do
         val body = stripLstOpt(m.group(2))                           // strip a leading [numbers=none] optional arg
         val en = CodeGlossary.renderCodeIds(body, extraId)


### PR DESCRIPTION
Addresses the agent-supported review in #958. Off `master` (both gate PRs merged). Thanks for the thorough review — and for enabling branch protection so `Example-compile-gate` is a required check.

**1 — correctness (the only one with weight).** The REPL result-echo classifier `(val|var)\s+\w+:.*=.*` was ASCII-only, so `var räknaLäte: Int = 0` (SV) wasn't classified as output while `var callCount: Int = 0` (EN) was — breaking the SV/EN classification symmetry that guarantees a mis-split can only skip, never false-flag. Fixed with a `(?U)` prefix. Verified: the SV line now classifies as output (was `false`), and a REPL fixture carrying that echo line self-compiles (`ok`) instead of self-skipping on a duplicate `var`.

**2** — phase-1 regression entries now print `file:line (env)` (like phase-2), so the actionable list is easy to locate.

**3** — `Latex.ifswedishRanges` warns on stderr when a range runs to EOF (unbalanced `\ifswedish`, e.g. a stray one in a comment/verbatim) — already conservative (skip, never mistranslate), now visible.

**4** — `ifswedishRanges` returns a named tuple `Seq[(start: Int, end: Int)]`; call sites (Translate + the gate) read `r.start`/`r.end`.

**5** — refreshed the gate usage header (root optional, `--list` documented).

**6** — noted the per-file scaffold repetition across the three loops is deliberate for a scratch tool (a shared HOF would add more indirection than it saves).

**7** — left as-is per your note (Code/CodeSmall don't take optional args).

Main project + gate both compile; negative REPL test still catches an injected regression (exit 1). Running the full clean gate locally to confirm 0 regressions with the new classifier (CI will also run the required check).
