### PR TITLE
compendium-en: fix missing ToC + w10 placeholder type-names

### DIFF
--- a/autotranslate/CodeGlossary.scala
+++ b/autotranslate/CodeGlossary.scala
@@ -203,6 +203,16 @@ object CodeGlossary:
       "Djur" -> "Animal", "Ko" -> "Cow", "Gris" -> "Pig", "Häst" -> "Horse",
       "väsnas" -> "makeNoise", "skapaDjur" -> "createAnimal", "bondgård" -> "farm",
     ),
+    // lect-w10-extends type-casting section (10.1.28/10.1.30): placeholder type-names in the inline
+    // \code{isInstanceOf[..]} / \code{asInstanceOf[..]} examples. Scoped here (NOT global) because `Typ` is a
+    // common token — a global Typ->Type would bleed into e.g. lect-wjava's \code{Klassnamn<Typ>} (mixed).
+    // BR-ratified 2026-07-24: EnVissTyp ("en viss typ") -> SomeType; Typ -> Type.
+    "lect-w10-extends" -> Map(
+      "EnVissTyp" -> "SomeType", "Typ" -> "Type",
+      // placeholder code-file names (10.1.26): KlassensNamn (capitalised, = the public class's name) ->
+      // ClassName; bastypensNamn (lowercase initial per the "multi-content file -> lowercase" rule) -> baseTypeName.
+      "KlassensNamn" -> "ClassName", "bastypensNamn" -> "baseTypeName",
+    ),
   )
   // Mirror-relative path substrings whose inline Scala-code envs SKIP the renderCodeIds pass entirely.
   val optOut: Set[String] = Set()

--- a/build.sbt
+++ b/build.sbt
@@ -126,8 +126,7 @@ def showTail(fileName: String, n: Int = 40): Unit = {
   println(lines.takeRight(n).mkString("\n"))
 }
 
-def runPdfLatexCmd(texFile: File, workDir: File, stdOutSuffix: String = "-console.log"): Unit = {
-  println(s" ******* Compiling $texFile to pdf *******")
+def runPdfLatexCmd(texFile: File, workDir: File, stdOutSuffix: String = "-console.log", maxPasses: Int = 1): Unit = {
   val cmd = scala.sys.process.Process(
     Seq("pdflatex","-halt-on-error", texFile.getName),
     workDir
@@ -135,9 +134,21 @@ def runPdfLatexCmd(texFile: File, workDir: File, stdOutSuffix: String = "-consol
   val cmdOutputFile =  workDir / texFile.getName.replace(".tex", stdOutSuffix)
   // val bibtexCmd = Process(Seq("bibtex", texFile.getName.replace(".tex", ".aux")), workDir)
 
-  // run pdflatex command TWICE in sequence to generate toc from .aux etc:
-  //val exitValue = cmd.#>(cmdOutputFile).#&&(cmd).#>(cmdOutputFile).run.exitValue
-  val exitValue = cmd.#>(cmdOutputFile).run.exitValue
+  // Run pdflatex until the .toc / cross-refs converge, i.e. until LaTeX stops asking to rerun — capped at
+  // maxPasses (like a tiny latexmk; avoids guessing 2 vs 3). The Swedish tasks default to 1 because their working
+  // dir (compendium/, slides/) keeps .aux/.toc across builds; the English mirror dirs are regenerated fresh every
+  // run, so pass 1 writes the .toc but never reads it (no ToC), pass 2 typesets it (which shifts pages), and a
+  // 3rd pass may be needed for the ToC/\pageref page numbers to settle. En tasks pass a cap of 4.
+  println(s" ******* Compiling $texFile to pdf (up to $maxPasses pass(es)) *******")
+  var exitValue = 0; var pass = 0; var rerun = true
+  while pass < math.max(1, maxPasses) && exitValue == 0 && rerun do
+    exitValue = cmd.#>(cmdOutputFile).run.exitValue
+    pass += 1
+    rerun = exitValue == 0 && {
+      val log = scala.util.Try(IO.read(cmdOutputFile)).getOrElse("")
+      log.contains("Rerun to get") || log.contains("Label(s) may have changed")
+    }
+  println(s"         ($pass pdflatex pass(es) run)")
   if (exitValue != 0) {
     println("*** ############ ERROR LOG STARTS HERE ############### ***")
     //Process(Seq("cat", cmdOutputFile.getName), workDir).run
@@ -225,7 +236,7 @@ def reportSwedishPct(autotranslateCp: String, pdf: File): Unit =
 lazy val pdfCompendiumEn = taskKey[Unit]("Compile the generated English mirror compendium-en/compendium-en.tex")
 pdfCompendiumEn := {
   val cp = (autotranslateProject / Compile / fullClasspath).value.files.map(_.getPath).mkString(java.io.File.pathSeparator)
-  runPdfLatexCmd(texFile = file("compendium-en.tex"), workDir = file("compendium-en"))
+  runPdfLatexCmd(texFile = file("compendium-en.tex"), workDir = file("compendium-en"), maxPasses = 4)
   reportSwedishPct(cp, file("compendium-en/compendium-en.pdf"))
 }
 
@@ -247,14 +258,14 @@ pdfCompendium2 := {
 lazy val pdfCompendium1En = taskKey[Unit]("Compile the generated English mirror compendium-en/compendium1-en.tex")
 pdfCompendium1En := {
   val cp = (autotranslateProject / Compile / fullClasspath).value.files.map(_.getPath).mkString(java.io.File.pathSeparator)
-  runPdfLatexCmd(texFile = file("compendium1-en.tex"), workDir = file("compendium-en"))
+  runPdfLatexCmd(texFile = file("compendium1-en.tex"), workDir = file("compendium-en"), maxPasses = 4)
   reportSwedishPct(cp, file("compendium-en/compendium1-en.pdf"))
 }
 
 lazy val pdfCompendium2En = taskKey[Unit]("Compile the generated English mirror compendium-en/compendium2-en.tex")
 pdfCompendium2En := {
   val cp = (autotranslateProject / Compile / fullClasspath).value.files.map(_.getPath).mkString(java.io.File.pathSeparator)
-  runPdfLatexCmd(texFile = file("compendium2-en.tex"), workDir = file("compendium-en"))
+  runPdfLatexCmd(texFile = file("compendium2-en.tex"), workDir = file("compendium-en"), maxPasses = 4)
   reportSwedishPct(cp, file("compendium-en/compendium2-en.pdf"))
 }
 
@@ -296,7 +307,7 @@ pdfSlidesEn := {
     val name = if (f.takeRight(4) == ".tex") f.dropRight(4) + "-en.tex" else f + "-en.tex"
     val texFile = file(name)
     println(s"runPdfLatexCmd($texFile, $workDir)")
-    runPdfLatexCmd(texFile, workDir)
+    runPdfLatexCmd(texFile, workDir, maxPasses = 4)
     reportSwedishPct(cp, new File(workDir, name.dropRight(4) + ".pdf"))
   }
 }


### PR DESCRIPTION
Two independent compendium-en output fixes found while reviewing the English build. See #960 for the ratification ask and the prose/cache decisions.

## 1. Missing table of contents (build fix)
`compendium-en.pdf` had no ToC. `runPdfLatexCmd` ran pdflatex once; a ToC needs ≥2 passes (pass 1 writes `.toc`, pass 2 typesets it, a 3rd may be needed since inserting the ToC shifts `\pageref` page numbers). The Swedish tasks survive on one pass because `compendium/`/`slides/` keep `.aux`/`.toc` across builds, but the English mirror dirs are regenerated fresh, so the single pass wrote `.toc` and never read it.

Fix: `runPdfLatexCmd` gains `maxPasses` and loops **until LaTeX stops asking to "Rerun"** (a tiny latexmk), capped — the minimum passes to converge, not a guessed 2 or 3. Swedish tasks keep cap 1 (unchanged); English tasks use cap 4. Verified on a fresh-dir rebuild: the ToC renders.

## 2. w10-extends placeholder type-names (pending ratification — #960)
Inline `\code{}` placeholders in `lect-w10-extends` missing from the glossary, scoped via `perFileId` (not global, so `Typ` can't bleed into `lect-wjava`'s `\code{Klassnamn<Typ>}`):

| Swedish | English | where |
|---|---|---|
| `EnVissTyp` | `SomeType` | 10.1.28 |
| `Typ` | `Type` | 10.1.30 |
| `KlassensNamn` | `ClassName` | 10.1.26 |
| `bastypensNamn` | `baseTypeName` | 10.1.26 |

Verified via `renderCodeIds`: all four translate under the `lect-w10-extends` path; `Typ` stays Swedish under `lect-wjava` (scoping holds). **English terms pending your ratification (#960).**

Model-free, English-only (Swedish build byte-identical). No new gate regressions.
