### PR TITLE
Update macOS tool installation

### DIFF
--- a/web/tools/tools.md
+++ b/web/tools/tools.md
@@ -225,14 +225,20 @@ Verifiera att det blev installerat:
 brew --version
 ```
 
-#### **Valfritt**: iTerm2
-MacOS kommer med en inbyggd terminal, men många föredrar att använda iTerm2 som är mer flexibel.
-Installera iTerm2 (valfritt) med:
+#### **Valfritt, rekommenderat**: kraftfullare terminal
+
+MacOS kommer med en inbyggd terminal, men denna brukar ersättas av ett mer flexibelt verktyg.
+
+Två vanliga alternativ är [Ghostty](https://ghostty.org/) och [iTerm2](https://iterm2.com/), som båda kan installeras med brew:
+
 ```bash
+brew install --cask ghostty
 brew install --cask iterm2
 ```
 
-Du kan nu stänga terminalen och öppna iTerm2.
+Är du osäker på vad skillnaden är så är Ghostty antagligen rätt för dig.
+
+Du kan nu stänga terminalen och öppna din nya terminal.
 
 ### 3) Installera OpenJDK 25
 

--- a/web/tools/tools.md
+++ b/web/tools/tools.md
@@ -201,9 +201,6 @@ defaults write NSGlobalDomain AppleShowAllExtensions -bool true && killall Finde
 defaults write com.apple.finder AppleShowAllFiles YES && killall Finder
 ```
 
-
-> macOS använder ofta `zsh` som standard. Det fungerar bra. Bash är valfritt.
-
 ### 2) Installera Homebrew
 Installera Homebrew genom att klistra:
 ```bash
@@ -228,25 +225,13 @@ Verifiera att det blev installerat:
 brew --version
 ```
 
-#### **Valfritt**: iTerm2 + Bash
+#### **Valfritt**: iTerm2
 MacOS kommer med en inbyggd terminal, men många föredrar att använda iTerm2 som är mer flexibel.
-Installera iTerm2 (valfritt) och Bash med:
+Installera iTerm2 (valfritt) med:
 ```bash
 brew install --cask iterm2
-brew install bash
 ```
 
-Nu kan du byta till bash:
-ARM:
-
-```bash
-chsh -s /opt/homebrew/bin/bash
-```
-
-x86:
-```bash
-chsh -s /usr/local/bin/bash
-```
 Du kan nu stänga terminalen och öppna iTerm2.
 
 ### 3) Installera OpenJDK 25


### PR DESCRIPTION
* Remove any mentions of opting into bash for mac.
* Suggest Ghostty as first choice of replacement for Terminal on mac. It is generally a faster and more elegant tool for the needs of an introprogger.

closes #972 